### PR TITLE
Update hardware.ts - jsHeapSizeLimit could not encode to JSON when using with protobuf

### DIFF
--- a/src/components/hardware/hardware.ts
+++ b/src/components/hardware/hardware.ts
@@ -9,7 +9,7 @@ function getHardwareInfo(): Promise<componentInterface> {
         'videocard': getVideoCard(),
         'architecture': getArchitecture(),
         'deviceMemory': deviceMemory.toString() || 'undefined',
-        'jsHeapSizeLimit': memoryInfo.jsHeapSizeLimit || 'undefined',
+        'jsHeapSizeLimit': memoryInfo.jsHeapSizeLimit || 0,
       }
     )
   });


### PR DESCRIPTION
currently, the type of jsHeapSizeLimit is a number or string (when could not get memory information, it return 'undefined').

this cause problem when using with protobuf, we must to set type of jsHeapSizeLimit to number or string (could not both as javascript)

and if we select number, on some device (like my iphone 15), it could not get memory information -> the value of jsHeapSizeLimit will be 'undefined' and will failed when encode back to protobuf value (know as number type).

for this reason, we return 0 when could not get information about memory