### PR TITLE
Fix: iframe layout shift

### DIFF
--- a/src/utils/ephemeralIFrame.ts
+++ b/src/utils/ephemeralIFrame.ts
@@ -7,6 +7,7 @@ export async function ephemeralIFrame(callback: ({ iframe }: { iframe: Document 
     iframe.setAttribute('frameBorder', '0')
 
     const style = iframe.style
+    style.setProperty('position','fixed');
     style.setProperty('display', 'block', 'important')
     style.setProperty('visibility', 'visible')
     style.setProperty('border', '0');

--- a/src/utils/ephemeralIFrame.ts
+++ b/src/utils/ephemeralIFrame.ts
@@ -10,6 +10,7 @@ export async function ephemeralIFrame(callback: ({ iframe }: { iframe: Document 
     style.setProperty('display', 'block', 'important')
     style.setProperty('visibility', 'visible')
     style.setProperty('border', '0');
+    style.setProperty('opacity','0');
     
     iframe.src = 'about:blank'
     document.body.appendChild(iframe)


### PR DESCRIPTION
Fixes #48

This PR adds an `opacity:0` to the iframe to hide the borders and also adds `position:fixed` to prevent layout shifts.
Tested on Edge, Chrome, Firefox, and Safari, these changes do not affect fingerprint calculation.