### PR TITLE
Fix: Prevent console.error in Jest tests by deferring WebGL canvas initialization

### DIFF
--- a/src/components/webgl/webgl.ts
+++ b/src/components/webgl/webgl.ts
@@ -7,14 +7,18 @@ const _RUNS = (getBrowser().name !== 'SamsungBrowser') ? 1 : 3;
 let canvas: HTMLCanvasElement
 let gl: WebGLRenderingContext | null = null;
 
-if (typeof document !== 'undefined') {
-  canvas = document.createElement('canvas');
-  canvas.width = 200;
-  canvas.height = 100;
-  gl = canvas.getContext('webgl');
+function initializeCanvasAndWebGL() {
+  if (typeof document !== 'undefined') {
+    canvas = document.createElement('canvas');
+    canvas.width = 200;
+    canvas.height = 100;
+    gl = canvas.getContext('webgl');
+  }
 }
 
 async function createWebGLFingerprint(): Promise<componentInterface> {
+  initializeCanvasAndWebGL();
+  
   try {
 
     if (!gl) {


### PR DESCRIPTION
### Context
We noticed that during our Jest tests, importing the `@thumbmarkjs/thumbmarkjs` package triggered a `console.error` (see attached screenshot). After investigating the issue, we identified that the error was caused by top-level code executed in the `webgl` component of the package. Specifically, a WebGL canvas was being created immediately upon import, which resulted in the error.

Jest’s environment does not support the WebGL API natively, which is why the top-level execution of this code led to errors in the test output.

![image](https://github.com/user-attachments/assets/f2959897-79ba-4f44-8b8f-d616d801a2ab)


### Proposed Fix
To address this issue, we encapsulated the canvas initialization in a function to ensure that no canvas is created upon import. The canvas will now only be created when explicitly required, avoiding unnecessary side effects during tests and preserving the intended functionality in non-test environments.

#### Changes:
- Encapsulated WebGL canvas initialization within a dedicated function.

### Testing & Verification
- Ran the test suite to confirm that no `console.error` is emitted when importing the package.
- Verified that WebGL functionality remains intact in non-test environments.

### Request for Review
Please review the proposed changes, and if any further modifications or improvements are needed, kindly let me know. Your feedback is greatly appreciated!
