### PR TITLE
[PR] Include option working on optionsInterface

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -47,6 +47,12 @@ export const getComponentPromises = () => {
             .filter(([key]) => {
                 return !options?.exclude?.includes(key)}
                 )
+            .filter(([key]) => {
+                return options?.include?.some(e => e.includes('.'))
+                    ? options?.include?.some(e => e.startsWith(key))
+                    : options?.include?.length === 0 || options?.include?.includes(key)
+            }
+                    )
             .map(([key, value]) => [key, value()])
     );
 }

--- a/src/fingerprint/options.ts
+++ b/src/fingerprint/options.ts
@@ -10,13 +10,14 @@ export interface optionsInterface {
 
 export let options: optionsInterface = {
     exclude: [],
+    include: [],
 }
 
 export function setOption<K extends keyof optionsInterface>(key: K, value: optionsInterface[K]) {
-    if (!['exclude', 'permissions_to_check', 'retries', 'timeout'].includes(key))
+    if (!['include', 'exclude', 'permissions_to_check', 'retries', 'timeout'].includes(key))
         throw new Error('Unknown option ' + key)
-    if (['exclude', 'permissions_to_check'].includes(key) && !(Array.isArray(value) && value.every(item => typeof item === 'string')) )
-        throw new Error('The value of the exclude and permissions_to_check must be an array of strings');
+    if (['include', 'exclude', 'permissions_to_check'].includes(key) && !(Array.isArray(value) && value.every(item => typeof item === 'string')) )
+        throw new Error('The value of the include, exclude and permissions_to_check must be an array of strings');
     if ([ 'retries', 'timeout'].includes(key) && typeof value !== 'number')
         throw new Error('The value of retries must be a number');
     options[key] = value;


### PR DESCRIPTION
I add some elements mainly on functions and factory script to handle 'include' options.
For example, an users wants to include only 'system' element to the final fingerprint, he can do now : 
` ThumbmarkJS.setOption('include', ['system'])`
Users can also add a fragment from an object like 'system.browser' or 'hardware.videocard' to get all descendants from these paths : 
`ThumbmarkJS.setOption('include', ['system.browser, 'hardware.videocard'])`

Finally I make some code improvements on filterFingerPrintData to make the code more clear, some code arrangements on excludeList and includeList parameters and added documentation on it for the readers.

I made some tests and it works but make some tests from your side to ensure that the fingerprint is consistent and correct

Please feel free to ask me anything that can help you