### PR TITLE
remove audio from Safari and Samsung. Add sources to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thumbmarkjs/thumbmarkjs",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "",
   "main": "./dist/thumbmark.cjs.js",
   "module": "./dist/thumbmark.esm.js",
@@ -13,7 +13,8 @@
   },
   "public": true,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "test": "jest",

--- a/src/components/audio/audio.ts
+++ b/src/components/audio/audio.ts
@@ -1,4 +1,5 @@
 import { componentInterface, includeComponent } from '../../factory'
+import { getBrowser } from '../system/browser'
 
 async function createAudioFingerprint(): Promise<componentInterface> {
   const resultPromise = new Promise<componentInterface>((resolve, reject) => {
@@ -58,4 +59,6 @@ function calculateHash(samples: Float32Array) {
   return hash;
 }
 
-includeComponent('audio', createAudioFingerprint);
+const browser = getBrowser()
+if (!['SamsungBrowser', 'Safari'].includes(browser.name))
+  includeComponent('audio', createAudioFingerprint);

--- a/src/components/system/browser.ts
+++ b/src/components/system/browser.ts
@@ -28,13 +28,16 @@ export function getBrowser(): BrowserResult {
       // Other browsers that use the format "BrowserName/version"
       /(?<name>[A-Za-z]+)\/(?<version>\d+(?:\.\d+)?)/,
       // Samsung internet browser
-      /(?<name>SamsungBrowser)\/(?<version>\d+(?:\.\d+)?)/
+      /(?<name>SamsungBrowser)\/(?<version>\d+(?:\.\d+)?)/,
+      // Samsung browser (Tizen format)
+      /(?<name>samsung).*Version\/(?<version>\d+(?:\.\d+)?)/i
     ];
   
     // Define a map for browser name translations
     const browserNameMap: { [key: string]: string } = {
-      'Edg': 'Edge',
-      'OPR': 'Opera'
+      'edg': 'Edge',
+      'opr': 'Opera',
+      'samsung': 'SamsungBrowser'
     };
 
     // Loop through the regexes and try to find a match
@@ -42,7 +45,7 @@ export function getBrowser(): BrowserResult {
       const match = ua.match(regex);
       if (match && match.groups) {
         // Translate the browser name if necessary
-        const name = browserNameMap[match.groups.name] || match.groups.name;
+        const name = browserNameMap[match.groups.name.toLowerCase()] || match.groups.name;
         // Return the browser name and version
         return {
           name: name,


### PR DESCRIPTION
This PR removes audio from SamsungBrowser and Safari browsers, as the audio is not a reliable source for these.
This PR also adds the source files to the NPM package that should fix https://github.com/thumbmarkjs/thumbmarkjs/issues/87