### PR TITLE
refactor: use same hash function for audio component as other components

### DIFF
--- a/src/components/audio/index.ts
+++ b/src/components/audio/index.ts
@@ -1,4 +1,5 @@
 import { componentInterface } from '../../factory'
+import { hash } from '../../utils/hash';
 
 export default async function getAudio(): Promise<componentInterface | null> {
   return createAudioFingerprint()
@@ -30,7 +31,7 @@ async function createAudioFingerprint(): Promise<componentInterface> {
         samples = event.renderedBuffer.getChannelData(0);
         resolve(
             {
-                'sampleHash': calculateHash(samples),
+                'sampleHash': hash(samples.toString()),
                 'maxChannels': audioContext.destination.maxChannelCount,
                 'channelCountMode': audioBuffer.channelCountMode,
 
@@ -50,13 +51,4 @@ async function createAudioFingerprint(): Promise<componentInterface> {
   
   return resultPromise;
 
-}
-
-
-function calculateHash(samples: Float32Array) {
-  let hash = 0;
-  for (let i = 0; i < samples.length; ++i) {
-    hash += Math.abs(samples[i]);
-  }
-  return hash;
 }


### PR DESCRIPTION
# Overview

Hi @ilkkapeltola , thanks for the work, I am using the open-source library here and like it.

Just wonder if the audio component should use the same hash function as canvas, webgl and the rest of the project, as it seems to be a much better hash function ?

I raised this PR for audio component to use the same hash.

I have been testing on a few browsers and the performance should not be affected.

 