### PR TITLE
Add Intl API fingerprint component

### DIFF
--- a/src/components/intl/index.test.ts
+++ b/src/components/intl/index.test.ts
@@ -1,0 +1,116 @@
+import getIntl from './index';
+
+describe('intl component tests', () => {
+  const originalIntl = globalThis.Intl;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'Intl', {
+      value: originalIntl,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  test('returns valid structure with all expected keys', async () => {
+    const result = await getIntl();
+
+    expect(result).not.toBeNull();
+    const coreKeys = [
+      'dateFullFormat', 'dateMediumFormat', 'timeFormat',
+      'numberFormat', 'currencyFormat', 'percentFormat',
+      'nonLatinDate', 'nonLatinNumber',
+    ];
+    for (const key of coreKeys) {
+      expect(result).toHaveProperty(key);
+      expect(typeof result![key]).toBe('string');
+    }
+  });
+
+  test('returns null when Intl is unavailable', async () => {
+    Object.defineProperty(globalThis, 'Intl', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await getIntl();
+    expect(result).toBeNull();
+  });
+
+  test('omits listFormat when ListFormat is unavailable', async () => {
+    const mockIntl = Object.create(originalIntl);
+    Object.defineProperty(mockIntl, 'ListFormat', {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'Intl', {
+      value: mockIntl,
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await getIntl();
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('dateFullFormat');
+    expect(result).not.toHaveProperty('listFormat');
+  });
+
+  test('omits displayNames when DisplayNames is unavailable', async () => {
+    const mockIntl = Object.create(originalIntl);
+    Object.defineProperty(mockIntl, 'DisplayNames', {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'Intl', {
+      value: mockIntl,
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await getIntl();
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('dateFullFormat');
+    expect(result).not.toHaveProperty('displayNames');
+  });
+
+  test('includes guarded probes when available', async () => {
+    const result = await getIntl();
+
+    expect(result).not.toBeNull();
+    if (typeof (Intl as any).ListFormat === 'function') {
+      expect(result).toHaveProperty('listFormat');
+      expect(typeof result!.listFormat).toBe('string');
+    }
+    if (typeof (Intl as any).DisplayNames === 'function') {
+      expect(result).toHaveProperty('displayNames');
+      expect(typeof result!.displayNames).toBe('string');
+    }
+  });
+
+  test('returns null when Intl constructor throws', async () => {
+    const mockIntl = Object.create(originalIntl);
+    Object.defineProperty(mockIntl, 'DateTimeFormat', {
+      value: () => { throw new Error('broken'); },
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'Intl', {
+      value: mockIntl,
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await getIntl();
+    expect(result).toBeNull();
+  });
+
+  test('produces deterministic number format output', async () => {
+    const result = await getIntl();
+
+    expect(result).not.toBeNull();
+    expect(result!.numberFormat).toBe('123,456.789');
+    expect(result!.currencyFormat).toBe('$123,456.79');
+    expect(result!.percentFormat).toBe('46%');
+  });
+});

--- a/src/components/intl/index.test.ts
+++ b/src/components/intl/index.test.ts
@@ -92,7 +92,7 @@ describe('intl component tests', () => {
   test('returns null when Intl constructor throws', async () => {
     const mockIntl = Object.create(originalIntl);
     Object.defineProperty(mockIntl, 'DateTimeFormat', {
-      value: () => { throw new Error('broken'); },
+      value: function() { throw new Error('broken'); },
       configurable: true,
     });
     Object.defineProperty(globalThis, 'Intl', {

--- a/src/components/intl/index.ts
+++ b/src/components/intl/index.ts
@@ -6,16 +6,16 @@ export default async function getIntl(): Promise<componentInterface | null> {
   }
 
   try {
-    const date = new Date(2024, 0, 15, 12, 30, 45);
+    const date = new Date(Date.UTC(2024, 0, 15, 12, 30, 45));
 
     const result: componentInterface = {
-      dateFullFormat: new Intl.DateTimeFormat('en-US', { dateStyle: 'full' } as any).format(date),
-      dateMediumFormat: new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' } as any).format(date),
+      dateFullFormat: new Intl.DateTimeFormat('en-US', { dateStyle: 'full', timeZone: 'UTC' } as any).format(date),
+      dateMediumFormat: new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeZone: 'UTC' } as any).format(date),
       timeFormat: new Intl.DateTimeFormat('en-US', { timeStyle: 'long', timeZone: 'UTC' } as any).format(date),
       numberFormat: new Intl.NumberFormat('en-US').format(123456.789),
       currencyFormat: new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(123456.789),
       percentFormat: new Intl.NumberFormat('en-US', { style: 'percent' }).format(0.456),
-      nonLatinDate: new Intl.DateTimeFormat('ar-EG').format(date),
+      nonLatinDate: new Intl.DateTimeFormat('ar-EG', { timeZone: 'UTC' }).format(date),
       nonLatinNumber: new Intl.NumberFormat('zh-Hans-CN-u-nu-hanidec').format(123456.789),
     };
 

--- a/src/components/intl/index.ts
+++ b/src/components/intl/index.ts
@@ -1,0 +1,36 @@
+import { componentInterface } from '../../factory';
+
+export default async function getIntl(): Promise<componentInterface | null> {
+  if (typeof Intl === 'undefined') {
+    return null;
+  }
+
+  try {
+    const date = new Date(2024, 0, 15, 12, 30, 45);
+
+    const result: componentInterface = {
+      dateFullFormat: new Intl.DateTimeFormat('en-US', { dateStyle: 'full' } as any).format(date),
+      dateMediumFormat: new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' } as any).format(date),
+      timeFormat: new Intl.DateTimeFormat('en-US', { timeStyle: 'long', timeZone: 'UTC' } as any).format(date),
+      numberFormat: new Intl.NumberFormat('en-US').format(123456.789),
+      currencyFormat: new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(123456.789),
+      percentFormat: new Intl.NumberFormat('en-US', { style: 'percent' }).format(0.456),
+      nonLatinDate: new Intl.DateTimeFormat('ar-EG').format(date),
+      nonLatinNumber: new Intl.NumberFormat('zh-Hans-CN-u-nu-hanidec').format(123456.789),
+    };
+
+    const IntlAny = Intl as any;
+
+    if (typeof IntlAny.ListFormat === 'function') {
+      result.listFormat = new IntlAny.ListFormat('en', { type: 'conjunction' }).format(['a', 'b', 'c']);
+    }
+
+    if (typeof IntlAny.DisplayNames === 'function') {
+      result.displayNames = new IntlAny.DisplayNames('en', { type: 'region' }).of('US') || '';
+    }
+
+    return result;
+  } catch {
+    return null;
+  }
+}

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -12,6 +12,7 @@ import getAudio from "./components/audio";
 import getCanvas from "./components/canvas";
 import getFonts from "./components/fonts";
 import getHardware from "./components/hardware";
+import getIntl from "./components/intl";
 import getLocales from "./components/locales";
 import getMath from "./components/math";
 import getPermissions from "./components/permissions";
@@ -33,6 +34,7 @@ export const tm_component_promises = {
     'canvas': getCanvas,
     'fonts': getFonts,
     'hardware': getHardware,
+    'intl': getIntl,
     'locales': getLocales,
     'math': getMath,
     'permissions': getPermissions,

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -12,7 +12,6 @@ import getAudio from "./components/audio";
 import getCanvas from "./components/canvas";
 import getFonts from "./components/fonts";
 import getHardware from "./components/hardware";
-import getIntl from "./components/intl";
 import getLocales from "./components/locales";
 import getMath from "./components/math";
 import getPermissions from "./components/permissions";
@@ -22,6 +21,7 @@ import getSystem from "./components/system";
 import getWebGL from "./components/webgl";
 
 // Import experimental component functions
+import getIntl from "./components/intl";
 import getWebRTC from "./components/webrtc";
 import getMathML from "./components/mathml";
 import getSpeech from "./components/speech";
@@ -34,7 +34,6 @@ export const tm_component_promises = {
     'canvas': getCanvas,
     'fonts': getFonts,
     'hardware': getHardware,
-    'intl': getIntl,
     'locales': getLocales,
     'math': getMath,
     'permissions': getPermissions,
@@ -50,6 +49,7 @@ export const tm_component_promises = {
  * @description key->function map of experimental components. Only resolved during logging.
  */
 export const tm_experimental_component_promises = {
+    'intl': getIntl,
     'mathml': getMathML,
 };
 


### PR DESCRIPTION
New component that calls Intl formatting APIs (DateTimeFormat, NumberFormat, ListFormat, DisplayNames) with fixed reference inputs. Different browsers and OS versions ship different ICU libraries, so the formatted output differs even when the locale is the same.

The existing `locales` component reads `navigator.language` and timezone but never calls `.format()`, so there is no overlap. Does not require any permissions.

Registered as an experimental component per maintainer feedback. All date formatters pin `timeZone: 'UTC'` for consistent output across timezones.