### PR TITLE
perf: 4-5× faster fingerprint() via component optimizations and WebGL context caching

### DIFF
--- a/docs/perf-notes.md
+++ b/docs/perf-notes.md
@@ -1,0 +1,471 @@
+# Performance notes
+
+A running log of perf investigations, measurements, and changes to thumbmarkjs.
+Each entry should be self-contained: motivation, measurement, what changed, what's
+deferred, and how to reproduce.
+
+---
+
+## 2026-05 — Pipeline instrumentation + four hash-stable wins
+
+### TL;DR
+
+Added diagnostic `_pipeline.*` timers to the post-component pipeline (gated on
+`options.performance`, so they only show up for callers that already opted into
+timing). They confirmed that under 20× CPU throttling the **wall-clock budget is
+overwhelmingly inside component sync preludes** — `_pipeline.dispatch = 955.9 ms`
+out of a 1064 ms total. The post-component pipeline (filter, stringify, hash,
+assembly) is essentially free even at 20× throttle.
+
+Also landed four hash-stable cleanups discovered while reading the pipeline:
+
+1. `raceAllPerformance` was leaking one `setTimeout(5000)` per component per call —
+   the timer was never cleared when the actual promise resolved first. 13 timers
+   per `tm.get()` accumulated indefinitely. Now refactored to use an explicit
+   `clearTimeout` when the real promise wins the race.
+2. `getBrowser()` (UA-parse with up to 12 regex matches) was being recomputed
+   inside every `getExcludeList` call, which is invoked from `filterThumbmarkData`
+   plus `resolveClientComponents` — at least twice per `tm.get()`. Now
+   memoized with a `Map<cacheKey, BrowserResult>` keyed on
+   `(navigator.brave ? 'B|' : 'N|') + navigator.userAgent`. Invalidates correctly
+   in tests since each test case mocks a distinct UA.
+3. `stableStringify` cycle detection used `seen.indexOf(node)` on an array
+   (O(N²) over a full traversal). Replaced `seen` with `Set<any>` for O(1)
+   lookups. Output string is byte-identical for non-cyclic input.
+4. `getAudio` had a stray `console.error('Error creating audio fingerprint:', error)`
+   in its catch path. Removed; the existing `reject(error)` already routes the
+   error through `raceAllPerformance`'s structured error channel.
+
+### Hash-stability verification
+
+| Phase | thumbmark hash |
+|---|---|
+| Pre-change baseline (Chrome / macOS) | `0ef8bdbc97de077c45a46358ecc4ba42` |
+| Post-change | `0ef8bdbc97de077c45a46358ecc4ba42` |
+| Stable across all 5 iterations | ✓ |
+
+Methodology: extended `test.html` to capture `res.thumbmark` per iteration into
+the title-encoded payload, with a sanity check that all iterations produce the
+same hash. Pre-change capture, code change, post-change capture, byte compare.
+The harness's `stable: true` field flags any drift across iterations.
+
+### Pipeline breakdown (20× CPU throttle, 5 iterations + 1 warm-up)
+
+| Phase | Median (ms) |
+|---|---:|
+| `_pipeline.dispatch` (sync component-fn calls, all 13) | **955.9** |
+| `_pipeline.resolve` (`await raceAllPerformance(...)`) | 97.4 |
+| `_pipeline.filter` (both filter calls combined) | 0.0 |
+| `_pipeline.stringify` | 0.0 |
+| `_pipeline.hash` | 0.1 |
+| `_pipeline.assembly` | 0.0 |
+| **TOTAL `tm.get()` wall-clock** | **1064.2** |
+
+`_pipeline.resolve` ≈ slowest component's async work (webrtc at 94 ms). All other
+components finish in parallel within that window. The 956 ms `dispatch` is the
+*serial* sync work of constructing each component's setup (`new
+OfflineAudioContext(...)`, canvas paints, WebGL context creation, etc.) — these
+all happen in the main thread before any `await` yields, and 13 of them queue up.
+
+### What did the four wins actually save?
+
+Almost nothing in this throttled scenario, because the post-component pipeline
+was already <1 ms even at 20× throttle. But:
+
+- **#1 (timer leak)** is a correctness bug, not a per-call perf win. Matters for
+  pages that call `tm.get()` repeatedly (each call previously left 13 5-second
+  timers hanging).
+- **#2 (`getBrowser` memoize)** would matter more on slow devices with very
+  complex UA strings (e.g. embedded webviews) and on pages that call `tm.get()`
+  many times.
+- **#3 (`stableStringify` `Set`)** would matter for users with bigger fingerprint
+  payloads (custom components, experimental components, many sub-keys).
+- **#4 (audio `console.error`)** is cleanliness, not perf.
+
+So these are good housekeeping but they don't move the 20× throttle median. The
+investigation was still worth it because it pointed at the real target.
+
+### Where the optimization opportunity actually lives
+
+`_pipeline.dispatch = 956 ms` at 20× throttle = ~47 ms unthrottled (rough scale).
+On a Moto G4-class device (4× / mid-tier) the budget is ~190 ms. That's the
+dispatch cost — sync work components do *before* their first `await`.
+
+Most of that work is fingerprint-essential (component setup that produces the
+hashed signal). But there are likely individual hot spots inside each component
+that could be trimmed without changing the data they emit. To find them
+surgically we need **per-component dispatch timing** (`_dispatch.audio`,
+`_dispatch.canvas`, …), which is a one-line extension of the existing
+instrumentation. Without that, picking which component to attack is guessing.
+
+### Deferred follow-ups
+
+1. **Per-component sync-dispatch timing.** Add `const t0 = performance.now(); const
+   p = fn(options); _dispatch[key] = performance.now() - t0; return p;` inside
+   the dispatch `.map`. Surface in `elapsed` under `_dispatch.<component>` keys.
+   Tells us which of the 13 components owns the 956 ms.
+2. **Refactor components to `await Promise.resolve()` first.** Cosmetic — pushes
+   sync work into the async portion so per-component `elapsed` is accurate. Total
+   wall-clock unchanged (single-threaded JS). Useful for diagnostics, not perf.
+3. **Inspect heavy-sync components for in-component wins.** Likely candidates:
+   audio (OfflineAudioContext + node graph setup), canvas (paints + readback),
+   fonts (multiple canvas paints per font), webgl (context + parameter queries).
+   Each may have hash-stable micro-optimizations (skip duplicate work, batch
+   paints, drop redundant queries) once we know which one dominates.
+4. **`stableStringify` further wins.** Drop `JSON.stringify(key)` in favour of
+   manual string-quoting for known-safe ASCII keys (saves a function call per
+   object key). Skip cycle detection entirely for fingerprint data (the path is
+   trusted to be acyclic). Both are tiny in absolute terms — only worth doing if
+   profile shows stringify mattering somewhere we haven't measured.
+5. **`raceAllPerformance` per-component timeout.** Today every component gets a
+   single global 5000 ms timeout. Could be per-component — but the success path
+   is unaffected, so this only helps abnormal scenarios.
+
+### Per-component dispatch timing (the next instrumentation pass)
+
+After the four wins above, we still had a 956 ms gap. We added per-component
+sync-dispatch instrumentation (`_dispatch.<name>` keys, alongside the
+`_pipeline.*` keys, populated when `options.performance` is true) to find which
+component owned the gap. Result at 20× throttle:
+
+| `_dispatch.<name>` | Median (ms) |
+|---|---:|
+| `_dispatch.webgl` | 599.9 |
+| `_dispatch.canvas` | 219.3 |
+| `_dispatch.fonts` | 138.2 |
+| `_dispatch.hardware` | 19.5 |
+| `_dispatch.webrtc` | 11.4 |
+| `_dispatch.audio` | 8.1 |
+| everything else | <8 each |
+
+WebGL alone was 60% of the entire dispatch budget. Canvas + fonts + webgl
+together were 90%.
+
+### WebGL component: module-scoped caching (browser-aware)
+
+`src/components/webgl/index.ts` was creating a **fresh canvas, GL context,
+compiled shader program, and vertex buffer on every call**. All of that work
+was repeated each `tm.get()` even though the inputs are constants — same
+shaders, same 137-spoke vertex array (computed via cos/sin per call from the
+same constants), same canvas size.
+
+The fix splits into two paths:
+
+- **Non-Brave browsers** (Chrome, Firefox, Safari, Edge, etc.): lazy-init the
+  canvas + GL context + shader program + vertex buffer on first call, cache them
+  at module scope, and reuse on subsequent calls. The expensive setup (shader
+  compile + program link, ~hundreds of ms throttled) becomes one-time. Per-call
+  work shrinks to `useProgram` + `bindBuffer` + `drawArrays` + `readPixels`.
+- **Brave**: the un-cached path is preserved exactly. Brave farbles WebGL
+  readPixels per-context — caching would give it a one-time fingerprint hash
+  shift. We sidestep that by detecting Brave via `getBrowser().name === 'Brave'`
+  and falling through to fresh-per-call setup.
+
+The constant 137-spoke vertex `Float32Array` is precomputed once at module load
+via an IIFE — applies to ALL browsers including Brave (it's pure data, not
+GL-context-tied, so byte-identical to what the per-call computation produced).
+
+### `getCommonPixels`: short-circuit + inline 3-way
+
+The webgl caching landed correctly (hash unchanged, `min` of 584 ms confirmed
+cached calls weren't paying setup cost) — but `_dispatch.webgl` only dropped
+from 599 → 642 ms. The setup wasn't the dominant cost. Reading `getWebGL`
+showed it has **no `await` anywhere**, so the `_dispatch.webgl` measurement
+includes the entire computation, not just the setup. The post-setup hot path
+calls `getCommonPixels(images, w, h)` followed by `hash(commonImageData.data.toString())`.
+
+`getCommonPixels` was the actual culprit. For a 200×100 RGBA image (80,000
+bytes) at `_RUNS=1` (every non-Samsung browser), it was doing:
+
+- 80,000 × `[indice].push(byte)` — new array allocation per byte
+- 80,000 × `getMostFrequent([byte])` — and that helper allocates a new
+  `frequencyMap = {}` object, sets one key, then does a `for...in` with
+  `parseInt(num, 10)` to convert the string key back to a number — all to find
+  "the most common of a single-element array" (which is always that element).
+- ~320,000 transient object/array allocations per call.
+
+Two fixes in `src/utils/commonPixels.ts`:
+
+1. **`images.length === 1` short-circuit** — return `images[0]` directly. Bytes
+   are byte-identical to what the algorithm would have produced. Massive win
+   for webgl (the common case).
+2. **`images.length === 3` inline branch** — `out[i] = (x===y) ? x : (x===z) ? x : (y===z) ? y : x`,
+   which is a direct algebraic encoding of the frequency-map logic and
+   preserves the original tie-breaking exactly:
+   - all-equal → that value (first ternary fires)
+   - 2-of-3 match → the matching value
+   - all-different → `arr[0]` (matches the original where `mostFrequent` stays
+     at `arr[0]` and no key has a frequency strictly greater).
+
+   Wins for canvas (always `_RUNS=3`) and Samsung WebGL (`_RUNS=3`).
+
+Generic-N fallback is preserved unchanged for hypothetical future callers.
+
+### Combined results (Chrome / macOS, 20× CPU throttle)
+
+| Metric | Baseline (before this whole sweep) | After 4 wins + instr. | After webgl cache | **After getCommonPixels** | Δ vs baseline |
+|---|---:|---:|---:|---:|---:|
+| TOTAL `tm.get()` wall-clock | 1100.6 ms | 1064.2 ms | 1166.1 ms | **342.1 ms** | **-69%** |
+| `_pipeline.dispatch` | (n/a; not yet instrumented) | 993.6 ms | 1037.5 ms | **222.3 ms** | — |
+| `_dispatch.webgl` | (n/a) | 599.9 ms | 642.7 ms | **33.6 ms** | -94% |
+| `_dispatch.canvas` | (n/a) | 219.3 ms | 218.1 ms | **20.9 ms** | -90% |
+| `_dispatch.fonts` | (n/a) | 138.2 ms | 134.2 ms | 124.5 ms | -10% |
+
+Hash on every measurement: **`0ef8bdbc97de077c45a46358ecc4ba42`**. Stable across
+all iterations every time.
+
+Scaled estimates:
+- Unthrottled (1×): ~52 ms → ~17 ms.
+- Mid-tier Android (4× / Moto G4 class): ~210 ms → ~67 ms.
+- Low-tier Android (6×): ~330 ms → ~100 ms.
+
+### Remaining slowest items (next targets)
+
+1. **`_dispatch.fonts` (124.5 ms)** — iframe creation forces layout/reflow, then
+   89 sync `measureText` calls. The iframe is the biggest single chunk. Caching
+   the iframe across calls would help multi-call use cases; single-call is
+   harder without risking hash drift (iframe vs main-document canvas could pick
+   up page-level `@font-face` rules).
+2. **`webrtc` async (~100 ms at 20×)** — sync `createOffer` and
+   `setLocalDescription` are browser-internal codec serialization. The only way
+   to skip these without changing the fingerprint hash is to pre-cache the
+   offer SDP for the session, since codec capabilities don't change during a
+   session — risk: subtle SDP variation across calls in some browsers.
+3. **`audio` (~23 ms)** — `OfflineAudioContext` rendering is browser-internal.
+   Hard to skip without changing the fingerprint.
+
+### Reproducer
+
+The harness now records the thumbmark hash, so pre/post comparisons are explicit:
+
+```bash
+# Pre-change
+osascript -e 'tell application "Google Chrome" to title of active tab of window 1'
+# Look for `__PERF__:{...}` and pull `thumbmark` field.
+
+# After code change + npm run build:
+osascript -e 'tell application "Google Chrome" to reload active tab of window 1'
+# Wait for `__PERF__:` title, compare `thumbmark` byte-for-byte to pre.
+```
+
+A `stable: false` field in the payload signals the hash drifted *across
+iterations* in the same run — a separate kind of bug from before/after drift.
+
+---
+
+## 2026-05 — `webrtc` component: removed ICE-candidate wait
+
+### TL;DR
+
+The `webrtc` fingerprint component was the slowest component on every measurement
+(13–27 ms median depending on CPU throttling). Most of that time was a race between
+a 4500 ms timeout and the first `icecandidate` event — captured purely to record a
+`candidateType` value that, with `iceServers: []`, is **always** `"host"` and adds
+zero entropy to the fingerprint.
+
+We removed the ICE wait, hardcoded `candidateType: 'host'` to preserve the
+fingerprint hash for the >>99% common path, and closed the `RTCPeerConnection`
+synchronously after extracting the SDP-derived data (which is the actual signal).
+
+### Pre-change measurement (CPU-throttled)
+
+Source: `test.html` perf harness (5 iterations after 1 warm-up), Chrome DevTools
+**6× CPU slowdown** (low-tier Android), library version 1.8.1.
+
+| Component | median (ms) | min | max |
+|---|---:|---:|---:|
+| **TOTAL (`tm.get()` wall-clock)** | **297.0** | 290.8 | 335.7 |
+| webrtc | 26.5 | 24.2 | 37.4 |
+| audio | 5.4 | 5.0 | 6.6 |
+| canvas | 0.9 | 0.1 | 1.2 |
+| fonts | 0.9 | 0.1 | 1.2 |
+| hardware | 0.9 | 0.0 | 1.2 |
+| locales | 0.9 | 0.0 | 1.2 |
+| math | 0.9 | 0.0 | 1.1 |
+| plugins | 0.1 | 0.0 | 1.1 |
+| screen | 0.1 | 0.0 | 1.0 |
+| system | 0.1 | 0.0 | 0.5 |
+| webgl | 0.0 | 0.0 | 0.5 |
+| speech | 0.0 | 0.0 | 0.1 |
+
+Notable: components sum to ~36 ms, but the TOTAL wall-clock is ~297 ms. The
+remaining ~260 ms lives outside the per-component instrumentation — likely
+`stableStringify` + hashing in `getThumbmark`, factory/promise scheduling, and
+cross-component awaits. Out of scope for this entry; tracked as a follow-up.
+
+### Why webrtc was slow
+
+The pre-change component flow:
+
+1. `new RTCPeerConnection({ iceCandidatePoolSize: 1, iceServers: [] })`
+2. `connection.createDataChannel('')` — registers media so the offer SDP gets generated
+3. `await createOffer({ offerToReceiveAudio: true, offerToReceiveVideo: true })` —
+   Chrome serializes the entire codec list into the SDP. **This is the actual
+   fingerprint signal.**
+4. `await setLocalDescription(offer)` — kicks off ICE gathering
+5. Regex-extract codecs/extensions from `offer.sdp`
+6. **Wait for the first `icecandidate` event with a 4500 ms timeout**
+7. Resolve with `{ ...compressedData, candidateType: 'host' }` (or `{ timeout: true }`
+   if the event never fires)
+
+Step 6 is the killer. With `iceServers: []`, Chrome only generates **host
+candidates** — local network interfaces, all reported as `candidateType === 'host'`.
+That field is invariant across users (every browser produces it), so it adds zero
+entropy to the hash. But the function spent its entire post-SDP time waiting for an
+event whose value was already known by construction.
+
+Estimated cost breakdown under 6× throttling:
+
+| Step | Cost (6× throttled) | Fingerprint signal? |
+|---|---:|---|
+| ctor + `createDataChannel` | ~2 ms | none |
+| `await createOffer` | ~6–8 ms | YES (whole codec list) |
+| `await setLocalDescription` | ~3 ms | none (kicks off ICE) |
+| SDP regex extraction | ~1–2 ms | YES |
+| **wait for `icecandidate`** | **~3–10 ms (variable)** | **none** |
+| `connection.close()` | ~1 ms | none |
+
+### Options considered
+
+| # | Approach | Code delta | Throttled saving | Hash stability |
+|---|---|---|---:|---|
+| **A** | **Drop the ICE wait. Hardcode `candidateType: 'host'`. Close immediately.** | ~25 lines removed, ~5 added | ~3–5 ms median | **stable for >>99% (the common-path users)** |
+| B | Same as A but remove `candidateType` from result | ~25 lines removed | ~3–5 ms median | breaks — hash changes for everyone |
+| C | Replace peer-connection dance with sync `RTCRtpReceiver.getCapabilities('audio'/'video')` | ~80 lines rewritten | ~22+ ms (≈ 0 ms residual) | breaks — different data shape, new hash |
+| D | Cache the result after first call (sessionStorage / module-scope memoize) | ~5 lines added | only helps 2nd+ call on same page | stable |
+
+We chose **Option A** for shippability: small, hash-stable for the common path, no
+new dependencies, no test surface to mock.
+
+### What changed
+
+`src/components/webrtc/index.ts` only. Two related edits in one file:
+
+1. **Removed the ICE wait** (the inner `Promise<componentInterface>` that wrapped a
+   `setTimeout` + `addEventListener('icecandidate', onIceCandidate)` race).
+   Hardcoded `candidateType: 'host'` in the result object so the hash is stable
+   for the previously-common-path users.
+
+2. **Fixed a pre-existing resource leak in the outer catch.** `connection` was
+   declared `const` inside the outer `try`, so if `new RTCPeerConnection()` or
+   `createDataChannel('')` threw synchronously, the outer catch could not safely
+   close the connection. Moved the declaration out as `let connection:
+   RTCPeerConnection | undefined`, added `connection?.close()` to the outer catch.
+
+The exported function signature is unchanged. The `options?: optionsInterface`
+parameter is intentionally retained for ABI stability even though `options.timeout`
+is no longer read (matches the pattern other components like `permissions` and
+`fonts` use).
+
+### Hash-stability analysis
+
+The result object now has shape `{ supported: true, audio, video, extensionsHash,
+candidateType: 'host' }` for the success path. Compared to the previous code:
+
+- **Users who previously hit the success path with `candidateType: 'host'`** (the
+  overwhelming majority — any browser that generated a host candidate within
+  4500 ms): hash is **identical**. No fingerprint regression.
+- **Users who previously hit the timeout path with `{ timeout: true }`** (rare —
+  browsers with aggressive WebRTC restrictions that never fire `icecandidate`):
+  hash **changes once**, then becomes stable forever. Net win: their fingerprint
+  was previously non-deterministic (sometimes `'host'`, sometimes `timeout: true`
+  depending on conditions), now it's deterministic.
+
+### Post-change measurement (CPU-throttled)
+
+Same harness, same throttling, same iteration count.
+
+| Component | median (ms) | Δ vs pre |
+|---|---:|---:|
+| **TOTAL** | **316.6** | +19.6 (within noise) |
+| **webrtc** | **23.4** | **−3.1** |
+| audio | 6.3 | +0.9 (within noise) |
+| canvas / fonts / hardware / locales / math | 1.0 | +0.1 (within noise) |
+| plugins / screen / system | 0.1 | unchanged |
+| webgl / speech | 0.0 | unchanged |
+
+The webrtc median dropped from 26.5 → 23.4 ms (-12%). The min dropped from 24.2 →
+21.8 ms.
+
+### Honest gap: predicted vs actual
+
+Before the change I estimated a 15–20 ms throttled saving on webrtc. The actual
+saving is closer to **3 ms median**. My estimate was wrong because I overweighted
+the `icecandidate` event-dispatch latency. With `iceServers: []`, the first host
+candidate is generated almost immediately after `setLocalDescription`, so the wait
+was much shorter than the worst-case 4500 ms timeout. Real throttled cost of the
+wait was on the order of 3–5 ms, not 15–20.
+
+What we got is still a real win — we removed both the wait *and* the timeout
+machinery, simplified the code, and reduced variance. But the bulk of webrtc's
+time (now ~23 ms throttled) lives in `await createOffer` and `await
+setLocalDescription` — which are Chrome-internal codec serialization and SDP
+processing. The only way to skip those is **Option C** (`RTCRtpReceiver.getCapabilities`),
+which requires accepting a fingerprint hash change.
+
+### Deferred follow-ups
+
+1. **No colocated test for `src/components/webrtc/index.ts`.** The component has
+   never had a test file. Adding one requires mocking `RTCPeerConnection` (and the
+   vendor-prefixed variants) in jsdom, which is non-trivial. Coverage worth adding:
+   feature-detect failure path, nominal SDP path, `createOffer` rejection path.
+2. **Per-descriptor `new RegExp()` allocation in `constructDescriptions`.** A
+   typical SDP yields 10–20 audio/video payload types; we currently allocate one
+   `RegExp` per descriptor per media type, ~20–40 RegExp constructions per
+   fingerprint call. A single-pass scan that groups SDP lines by payload ID into a
+   `Map` would reduce that to O(1) regex compilation. Pre-existing — not addressed
+   in this change.
+3. **The 260 ms gap between summed components and TOTAL wall-clock** (under 6×
+   throttling). Most likely lives in `stableStringify` + hashing in
+   `src/functions/index.ts` and in promise/factory scheduling. A `performance.mark`
+   /`performance.measure` pair around `getThumbmark`'s post-component pipeline
+   would localize it.
+4. **Option C — `RTCRtpReceiver.getCapabilities`.** ~22 ms additional throttled
+   saving available. Requires a fingerprint hash bump (different data shape).
+   Defensible on a 1.x → 1.(x+1).0 minor or a 2.0.0 major.
+5. **Bootstrap the Playwright perf bench.** `perf/perf.spec.ts` exists but its
+   Playwright config is broken (`tm-js-perf` reported a config-resolution failure;
+   the file itself has a TS2048 implicit-`any` error on `reduce` callback params).
+   Until that's fixed, perf regression checks rely on the manual `test.html`
+   harness rather than a deterministic CI bench.
+
+### How to reproduce the measurement
+
+The repo ships a self-contained perf harness at `test.html`. It loads the local
+UMD build (`dist/thumbmark.umd.js`) and exposes a UI to run N iterations of
+`tm.get({ performance: true })`, then renders a sorted timing table.
+
+Useful tricks the harness supports:
+
+- **Title-encoded results.** After a run completes, `document.title` is set to
+  `__PERF__:{...json...}` containing the version, CPU note, and per-component
+  timings. This lets external pollers (AppleScript, Bash) read the numbers without
+  needing CDP / chrome-devtools MCP access.
+- **Re-run button.** DevTools CPU throttling persists across re-runs while
+  DevTools stays open, so you can change the throttle dropdown and click Re-run
+  to compare 1× / 4× / 6× without losing throttling state.
+- **`?cpu=` query param.** Pre-fills the CPU note for the run summary so the
+  console log carries the throttling state.
+
+Reproduce:
+
+```bash
+# Build
+npm run build
+
+# Serve (any static server works; python is built-in on macOS)
+python3 -m http.server 4173 --bind 127.0.0.1 &
+
+# Open the harness, then in DevTools → Performance → CPU dropdown set
+# "4x slowdown" (mid-tier Android — Lighthouse mobile default, Moto G4 class) or
+# "6x slowdown" (low-tier). Reload or click Re-run.
+open "http://127.0.0.1:4173/test.html?cpu=4x"
+```
+
+To poll the title from a CLI (macOS, Chrome must be running with the test.html
+tab somewhere):
+
+```bash
+osascript -e 'tell application "Google Chrome" to title of active tab of window 1'
+# Look for output starting with `__PERF__:` then JSON.parse the rest.
+```

--- a/docs/perf-optimization-report.md
+++ b/docs/perf-optimization-report.md
@@ -1,0 +1,397 @@
+# Performance optimization report — May 2026
+
+**Library version under investigation:** thumbmarkjs 1.8.1
+**Test environment:** Chrome on macOS, throttled via Chrome DevTools CPU dropdown
+**Session outcome:** `tm.get()` wall-clock at 20× CPU throttle dropped from
+**1038 ms → 331 ms** (3.14× faster, −68%), with the produced fingerprint hash
+**byte-identical to the published 1.8.1 release** on the same machine.
+
+If you only read one paragraph: a single side-by-side run loaded the published
+1.8.1 from jsDelivr in one Chrome tab and our optimized local 1.8.1 build in
+the same tab via a query-string switch. Both produced thumbmark
+`0ef8bdbc97de077c45a46358ecc4ba42`. The optimized build was 3× faster. Same
+input, same output — the speedup came purely from removing wasted work.
+
+## Headline numbers
+
+All measurements: Chrome on macOS, **DevTools CPU at 20× slowdown**, 5 iterations
++ 1 warm-up. The 20× throttle is more aggressive than any real device but
+makes bottlenecks unmissable; saving N ms there scales roughly linearly down to
+unthrottled (~N/20 ms saving on a fast PC).
+
+| | Published 1.8.1 (CDN) | Optimized local 1.8.1 | Δ |
+|---|---:|---:|---:|
+| TOTAL `tm.get()` wall-clock | **1038 ms** | **331 ms** | **−68%** |
+| Reported library version | 1.8.1 | 1.8.1 | identical |
+| **Thumbmark hash** | **`0ef8bdbc97de077c45a46358ecc4ba42`** | **`0ef8bdbc97de077c45a46358ecc4ba42`** | **identical** |
+| Hash stable across iterations | ✓ | ✓ | both stable |
+
+Scaled estimates (linear in throttle):
+- Unthrottled fast PC: ~52 ms → ~17 ms.
+- Mid-tier Android (4× / Moto G4 class, Lighthouse mobile default): ~210 ms → ~67 ms.
+- Low-tier Android (6×): ~330 ms → ~100 ms.
+
+156/156 Jest tests pass on every step of the chain. Nothing has been committed
+yet; all changes live on the working tree awaiting review.
+
+## Why this work was started
+
+Initial inspection: `webrtc` was the slowest component on every measurement.
+Reading the code revealed it spent most of its time waiting for the first
+`icecandidate` event purely to capture a `candidateType` field that, with
+`iceServers: []`, is *always* `'host'` — zero entropy in the fingerprint hash.
+That motivated the broader question: where else is the library doing work that
+doesn't contribute to the hash?
+
+## Method
+
+A self-contained perf harness lives in `test.html` (root of the repo) and was
+extended over the session into a measurement tool with these properties:
+
+1. **Source toggle.** A `?source=local|cdn` query param (also a dropdown in the
+   page) decides whether to load `./dist/thumbmark.umd.js` or
+   `https://cdn.jsdelivr.net/npm/@thumbmarkjs/thumbmarkjs/dist/thumbmark.umd.js`.
+   Same harness, swappable build — that's how the headline comparison above
+   was generated.
+2. **Per-iteration timing.** Wraps `await tm.get({ performance: true })` in
+   `performance.now()` to capture wall-clock + the per-component `elapsed` map
+   that `options.performance` exposes.
+3. **Hash capture + stability check.** Captures `res.thumbmark` per iteration
+   and flags any drift across the 5 iterations of a single run.
+4. **Title-encoded payload.** After each run, encodes everything (source, version,
+   total median/min/max, per-component medians, thumbmark hash, stability flag)
+   into `document.title` as `__PERF__:{...json...}`. This let an external poller
+   (a small AppleScript loop on macOS reading the active Chrome tab's title)
+   capture results without needing CDP / chrome-devtools-MCP access. That made
+   the round-trip "edit code → rebuild → reload → capture numbers" tight.
+5. **CPU throttling via DevTools.** Performance panel → CPU dropdown → 4× / 6× /
+   20×. Persists across reloads while DevTools stays open, so each round trip
+   keeps the same throttle.
+
+### Hash-stability discipline
+
+Every measurement run captured the thumbmark hash. The session anchor was
+`0ef8bdbc97de077c45a46358ecc4ba42` (the value the published 1.8.1 produces on
+the test machine). Before each code change we re-captured the pre-change hash;
+after each rebuild we re-captured the post-change hash. Any byte mismatch was
+treated as an immediate revert. The harness's `stable: true` field also
+confirmed *intra-run* hash stability across the 5 iterations.
+
+### Diagnostic instrumentation
+
+Beyond the user-facing per-component `elapsed`, we added two new families of
+keys (gated on `options.performance` so they only show up for callers that
+already opted into timing):
+
+- `_pipeline.<phase>` — per-phase timings inside `getThumbmark`:
+  `_pipeline.dispatch` (sync time of calling all 13 component functions),
+  `_pipeline.resolve` (`await raceAllPerformance`), `_pipeline.filter`,
+  `_pipeline.stringify`, `_pipeline.hash`, `_pipeline.assembly`.
+- `_dispatch.<componentName>` — per-component sync-prelude timing. Captures how
+  long each component's `async function` body runs *synchronously* before its
+  first `await` yields. This was the key revelation of the session: most of the
+  budget lived in component sync work, not in the post-component pipeline.
+
+Both families are in `elapsed` only, never in `components`. The hash is computed
+from `components`, so timing data has no effect on the fingerprint. Verified
+empirically (hash unchanged before/after instrumentation landed).
+
+## What we changed
+
+Eight discrete changes, in the order they landed. Each was verified
+hash-equivalent on the test machine before moving on.
+
+### 1. `webrtc` — drop the ICE-candidate wait
+`src/components/webrtc/index.ts`
+
+The component called `createOffer` + `setLocalDescription`, regex-extracted
+codec/extension/fmtp data from `offer.sdp`, and *additionally* waited up to
+4500 ms for the first `icecandidate` event to capture `candidateType`. With
+`iceServers: []`, every browser produces only host candidates →
+`candidateType === 'host'` always → zero entropy in the hash. The wait was
+~3-5 ms even when fast (host candidates fire quickly), but the timeout machinery
++ event listener + race wrapper was pure overhead.
+
+We deleted the inner `Promise<componentInterface>` race, hardcoded
+`candidateType: 'host'` in the result (preserves the hash for everyone who
+previously hit the success path — virtually all users), and closed the
+connection synchronously after extracting SDP data.
+
+While in the file, fixed a pre-existing resource leak: if
+`new RTCPeerConnection(config)` or `connection.createDataChannel('')` threw
+synchronously, the outer catch couldn't safely call `connection.close()`
+(`connection` was either in TDZ or assigned-but-never-closed). Moved the
+declaration to a `let connection: RTCPeerConnection | undefined` outside the
+try; added `connection?.close()` to the outer catch.
+
+### 2. `raceAllPerformance` — clear the loser timer
+`src/utils/raceAll.ts`
+
+The pattern `Promise.race([component, delay(timeoutTime, timeoutVal)])` never
+cleared the `setTimeout` when the component promise settled first. Each
+`tm.get()` was leaking 13 timers (one per component, default 5000 ms each)
+that ran to completion in the background. Repeated calls accumulated.
+
+Refactored to track the timeout ID explicitly and `clearTimeout` it from the
+component-side `.then` and `.catch`. Public API of `raceAllPerformance`,
+`raceAll`, and `delay` are all unchanged. Existing `raceAll.test.ts` passes
+without modification.
+
+### 3. `getBrowser` — memoize
+`src/components/system/browser.ts`
+
+`getBrowser()` performs up to 12 sequential regex `.match()` calls on the user
+agent. It's invoked by `getExcludeList`, which is called from
+`filterThumbmarkData` and `resolveClientComponents` — at least twice per
+`tm.get()`.
+
+Added a module-scoped `Map<cacheKey, BrowserResult>` keyed on
+`(navigator.brave ? 'B|' : 'N|') + navigator.userAgent`. The Brave prefix is
+necessary because Brave masks its UA but reports a different `name` than the
+underlying browser. Tests stay green: each test case mocks a distinct UA →
+distinct cache key → no stale-cache bleed-through.
+
+### 4. `stableStringify` — Set-based cycle detection
+`src/utils/stableStringify.ts`
+
+Cycle detection used `seen.indexOf(node)` on a `seen: any[]` array — O(N)
+per visit, O(N²) over a full traversal. Fingerprint data is acyclic by
+construction, so the check never trips, but it ran anyway on every node visit.
+
+Replaced `seen` with `Set<any>`. `seen.has` (O(1)), `seen.add`, `seen.delete`.
+The serialization logic — key sorting, value recursion, comma joining, brace
+emission — is byte-identical. Output for any non-cyclic input is byte-identical.
+Hash unchanged.
+
+### 5. `audio` — remove `console.error`
+`src/components/audio/index.ts`
+
+`getAudio` had a stray `console.error('Error creating audio fingerprint:', error)`
+in its error path. Public OSS libraries shouldn't write to the browser console
+from their hot path. The next line `reject(error)` already routes the error
+through `raceAllPerformance`'s structured error channel. Just deleted the line.
+
+### 6. Pipeline + per-component instrumentation (diagnostic)
+`src/functions/index.ts`
+
+After (1)-(5) landed, the throttled total was essentially unchanged. We
+needed to know *where* the time was actually going, so we added the
+`_pipeline.*` and `_dispatch.<name>` instrumentation described in the
+**Method** section above.
+
+The first instrumented run made the situation obvious:
+
+| Phase at 20× throttle | Median (ms) |
+|---|---:|
+| `_pipeline.dispatch` (sync of all 13 component fns) | 955.9 |
+| `_pipeline.resolve` (await raceAllPerformance) | 97.4 |
+| `_pipeline.filter` / `.stringify` / `.hash` / `.assembly` | < 0.1 each |
+
+The post-component pipeline was already optimal. The 956 ms gap was sync
+component-prelude work — JS in component bodies that runs synchronously when
+the function is called, before any `await` yields. Per-component timing
+narrowed it further:
+
+| `_dispatch.<name>` | Median (ms) |
+|---|---:|
+| `_dispatch.webgl` | 599.9 (60% of dispatch) |
+| `_dispatch.canvas` | 219.3 (22%) |
+| `_dispatch.fonts` | 138.2 (14%) |
+| everything else | < 20 each |
+
+That established the targets for (7) and (8).
+
+### 7. `webgl` — module-scoped caching (browser-aware)
+`src/components/webgl/index.ts`
+
+The component was creating a fresh canvas, fresh GL context, freshly compiled
+shader program, freshly created vertex buffer, and freshly computed 137-spoke
+`Float32Array` on every call. All of those inputs are constants. Shader
+compile + program link is the most expensive WebGL operation on most browsers.
+
+Refactored:
+- Module-level constants for canvas dimensions (200×100), spoke count (137),
+  shader source strings.
+- Module-level `_VERTICES` IIFE that precomputes the spoke `Float32Array` once
+  at module load. Pure data, not GL-context-tied — applies to *all* browsers
+  including Brave.
+- `setupWebGL(): WebGLCache | null` encapsulates the full setup (canvas + gl +
+  shaders + program + buffer). Returns null on any failure.
+- `_USE_CACHE = getBrowser().name !== 'Brave'`. For non-Brave browsers, lazy-init
+  the `WebGLCache` on first call, reuse on subsequent calls. For Brave: always
+  call `setupWebGL` fresh (Brave farbles WebGL `readPixels` per-context;
+  caching would shift their hash once).
+- `renderImage(cache)` does only `useProgram` + `bindBuffer` + `drawArrays` +
+  `readPixels` + state reset. No setup work.
+
+Other privacy browsers (Tor, Firefox-RFP) typically disable WebGL entirely or
+return constants — caching gives byte-identical output in those cases too.
+
+### 8. `getCommonPixels` — short-circuit + inline 3-way
+`src/utils/commonPixels.ts`
+
+After (7) the throttled webgl number had barely moved. Reading `getWebGL`
+explained why: it has no `await` keyword anywhere, so `_dispatch.webgl`
+includes the entire computation, not just the setup. The actual hot spot was
+`getCommonPixels`, which for `_RUNS=1` (the every-non-Samsung case) was doing
+80,000+ allocations to find "the most common byte of a single-element array" —
+which is always that single byte:
+
+```ts
+// per byte position (× 80,000 for 200×100 RGBA):
+let indice: number[] = [];                       // new array
+for (let u = 0; u < images.length; u++)          // images.length === 1
+  indice.push(images[u].data[i]);
+finalData.push(getMostFrequent(indice));         // grows finalData via .push()
+
+// inside getMostFrequent:
+const frequencyMap: { [key: number]: number } = {};   // new object
+for (const num of arr) frequencyMap[num] = ...;
+for (const num in frequencyMap)                       // iterates string keys
+  if (...) mostFrequent = parseInt(num, 10);          // parseInt to recover num
+```
+
+Two surgical changes:
+
+- `if (images.length === 1) return images[0]` — short-circuit. Output bytes
+  are byte-identical (most common of `[x]` is `x`). Massive win for webgl
+  (the common case).
+- For `images.length === 3` (canvas always, Samsung webgl): replace the
+  per-byte `getMostFrequent` call with the inline ternary
+  `out[i] = (x===y) ? x : (x===z) ? x : (y===z) ? y : x`. This preserves the
+  original tie-breaking exactly (all-equal / 2-of-3-match / all-different cases
+  fall through to the same answer the frequency-map algorithm would give).
+  Wins for canvas (always `_RUNS=3`) and Samsung webgl.
+
+Generic-N fallback preserved unchanged for any future caller using N other
+than 1 or 3.
+
+This was the change that moved the headline number. After it landed:
+`_dispatch.webgl` 642 → 33.6 ms (−95%), `_dispatch.canvas` 218 → 20.9 ms
+(−90%), TOTAL 1166 → 342 ms (−71%).
+
+## Hash-stability proof
+
+Three independent layers of evidence:
+
+1. **Code-level reasoning.** Every change either operates on data that's
+   downstream-equivalent (length-1 short-circuit, length-3 inline tie-break),
+   touches code paths the hash never reaches (timing instrumentation in
+   `elapsed`, console.error removal, timer cleanup, cycle-detection internals),
+   or substitutes module-cached objects whose outputs are byte-identical to
+   freshly-created ones for non-noise-injecting browsers (webgl).
+2. **Per-iteration intra-run stability.** The harness compares
+   `res.thumbmark` across the 5 iterations of every run; `stable: true` was
+   reported on every measurement of the session.
+3. **CDN-vs-local cross-build equivalence.** The published 1.8.1 (which carries
+   none of our changes) and the optimized local 1.8.1 were loaded into the same
+   Chrome instance with the same CPU throttling and produced byte-identical
+   thumbmarks. This is the definitive empirical proof.
+
+## Trade-offs and what we did *not* change
+
+**Acceptable hash-changing scenarios.** Two of our changes can shift the hash
+for narrow user populations. Both are documented and both are net-stability
+improvements:
+
+- *webrtc*: users who previously hit the timeout path
+  (`{ supported: true, ...compressed, timeout: true }` instead of
+  `{ ...compressed, candidateType: 'host' }`) get a one-time hash change. These
+  users were already getting a non-deterministic fingerprint (the timeout fires
+  based on network conditions). Now they get a deterministic one.
+- *webgl*: caching is *off* for Brave specifically. For Tor / Firefox-RFP /
+  other privacy browsers that disable WebGL or return constants, caching gives
+  byte-identical output to the un-cached path — no hash impact.
+
+**Hash-stable opportunities not pursued.** Documented in
+`docs/perf-notes.md` for follow-up:
+
+- *fonts iframe caching*: caching the iframe across `tm.get()` calls would
+  help repeated-call use cases (~30-60 ms saving for 2nd+ call). Single-call
+  savings are zero. Not done because most thumbmarkjs callers do one
+  `tm.get()` per page.
+- *stableStringify micro-tweaks*: `JSON.stringify(key)` in a hot loop could
+  be replaced with manual ASCII-safe quoting; cycle detection could be removed
+  entirely (fingerprint data is trusted to be acyclic). Both are sub-millisecond
+  in the measurements we have. Worth doing only if a profile shows
+  `_pipeline.stringify` somewhere we haven't measured.
+
+**Hash-changing options not pursued (would have been bigger wins).**
+
+- *WebRTC Option C*: replace the peer-connection dance with sync
+  `RTCRtpReceiver.getCapabilities('audio'/'video')`. Would drop webrtc to <1 ms
+  unthrottled, ~2-3 ms throttled. Different data shape → different hash. Worth
+  considering for a 2.0.0 major bump.
+- *Skipping/restructuring components*: any change to what data audio / canvas /
+  fonts / webgl emit would change the hash. Out of scope for this session per
+  the user's "preserve fingerprint" constraint.
+
+## Open follow-ups
+
+By remaining throttled cost, in order:
+
+1. **`_dispatch.fonts` (124.5 ms at 20× post-optimization).** iframe creation
+   forces layout/reflow + 89 sync `measureText` calls. iframe caching across
+   calls (helps multi-call use), or main-document canvas (risks drift if page
+   has custom `@font-face`). Largest remaining hash-stable target.
+2. **`webrtc` async (~100 ms).** Browser-internal codec serialization in
+   `createOffer` + `setLocalDescription`. Floor cost in the current architecture.
+3. **`audio` (~23 ms).** `OfflineAudioContext.startRendering()` is
+   browser-internal. Floor cost.
+4. **Bootstrap the Playwright perf bench.** `perf/perf.spec.ts` exists in the
+   repo but its config doesn't resolve (the implementor for the perf agent
+   reported a TS2048 implicit-`any` on a `reduce` callback there). Until that's
+   fixed, perf regressions are caught only by the manual `test.html` harness,
+   not by CI.
+5. **WebGL component-loss handling.** The cached `WebGLCache` survives across
+   `tm.get()` calls but doesn't recover from `webglcontextlost` events
+   (suspended tab → context destroyed). Today: the cached null persists, so
+   webgl reports `unsupported` until the next page load. Not seen in practice
+   but worth a recovery hook eventually.
+
+## Files changed (for review)
+
+```
+ M src/components/webrtc/index.ts        # change 1
+ M src/utils/raceAll.ts                  # change 2
+ M src/components/system/browser.ts      # change 3
+ M src/utils/stableStringify.ts          # change 4
+ M src/components/audio/index.ts         # change 5
+ M src/functions/index.ts                # change 6 (instrumentation)
+ M src/components/webgl/index.ts         # change 7
+ M src/utils/commonPixels.ts             # change 8
+?? docs/perf-notes.md                    # running perf log (this session + future)
+?? docs/perf-optimization-report.md      # this report
+?? test.html                             # harness with source toggle + hash capture
+```
+
+156/156 Jest tests pass. `npm run build` clean. No new runtime dependencies.
+The exported public API surface of the library is unchanged. The `elapsed`
+field gains the `_pipeline.*` and `_dispatch.<name>` keys when
+`options.performance: true`; consumers of `elapsed` who don't recognize those
+keys will simply ignore them.
+
+## Reproducing the comparison
+
+In one terminal, from the repo root:
+
+```bash
+npm run build
+python3 -m http.server 4173 --bind 127.0.0.1
+```
+
+In Chrome with DevTools open and **CPU throttling at 20× slowdown** (Performance
+panel → CPU dropdown):
+
+- `http://127.0.0.1:4173/test.html?source=local&cpu=20x` — optimized local build
+- `http://127.0.0.1:4173/test.html?source=cdn&cpu=20x` — published 1.8.1 from
+  jsDelivr
+
+Each page auto-runs and renders a sorted timing table. The thumbmark hash is
+visible in the page (raw last-run elapsed pane shows the elapsed map; the
+console shows `[thumbmarkjs perf] thumbmark: <hash>`). The full result is also
+JSON-encoded into `document.title` as `__PERF__:{...}` for programmatic
+capture.
+
+Both builds should produce thumbmark `0ef8bdbc97de077c45a46358ecc4ba42` on the
+same browser/device; the wall-clock should differ by ~3×.

--- a/e2e/webgl-context-loss.spec.ts
+++ b/e2e/webgl-context-loss.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * End-to-end test: WebGL context-loss recovery.
+ *
+ * Verifies that when the browser fires a webglcontextlost event on the
+ * canvas the library has cached, a subsequent tm.get() call rebuilds
+ * the WebGL context from scratch and produces an identical fingerprint.
+ *
+ * Prerequisites:
+ *   - A static HTTP server must be running on http://localhost:3333
+ *     serving the repo root (so /dist/thumbmark.umd.js is reachable).
+ *   - The library must have been built: `npm run build`.
+ *
+ * The test does NOT spawn a server itself; the orchestrator is responsible
+ * for starting one before invoking `npx playwright test`.
+ */
+
+test.describe('WebGL context-loss recovery', () => {
+  test('fingerprint is stable after WEBGL_lose_context.loseContext()', async ({ page }) => {
+    // Patch getContext BEFORE the page (and its scripts) load so that
+    // every WebGLRenderingContext the library creates is captured in
+    // window.__capturedGLs.  Playwright's addInitScript() runs in the
+    // page context before any <script> on the page executes — ideal.
+    await page.addInitScript(() => {
+      const origGetContext = HTMLCanvasElement.prototype.getContext;
+      (window as any).__capturedGLs = [] as WebGLRenderingContext[];
+
+      (HTMLCanvasElement.prototype as any).getContext = function (...args: any[]) {
+        const ctx = origGetContext.apply(this, args as any);
+        if (args[0] === 'webgl' && ctx) {
+          (window as any).__capturedGLs.push(ctx);
+        }
+        return ctx;
+      };
+    });
+
+    // Navigate to a blank page on the static server, then inject the UMD bundle directly.
+    // This avoids depending on any specific HTML file existing in the repo root.
+    await page.goto('http://localhost:3333/');   // 200 OK from http-server's directory listing is fine
+    await page.addScriptTag({ url: '/dist/thumbmark.umd.js' });
+    await page.waitForFunction(() => !!(window as any).ThumbmarkJS);
+
+    // -----------------------------------------------------------------------
+    // First tm.get() — warms up the WebGL cache inside the library
+    // -----------------------------------------------------------------------
+    const result1 = await page.evaluate(async () => {
+      // @ts-ignore — ThumbmarkJS loaded via <script>
+      const tm = new ThumbmarkJS.Thumbmark();
+      // Exclude the speech component: in headless Chromium speechSynthesis.getVoices()
+      // returns 0 voices on some runs and 68 on others depending on whether
+      // 'voiceschanged' fires before the component's internal timeout. This is a
+      // pre-existing flakiness unrelated to the webgl context-loss recovery we're
+      // testing. Excluding it isolates the test to the WebGL behavior under test.
+      const data = await tm.get({ exclude: ['speech'] });
+      return {
+        thumbmark: data.thumbmark as string,
+        commonPixelsHash: (data.components?.webgl as any)?.commonPixelsHash as string | undefined,
+      };
+    });
+
+    // WebGL must have produced a real hash, not the 'unsupported' fallback
+    expect(result1.commonPixelsHash).toBeDefined();
+    expect(result1.commonPixelsHash).not.toBe('unsupported');
+
+    // -----------------------------------------------------------------------
+    // Force context loss on the library's cached GL context
+    // -----------------------------------------------------------------------
+    await page.evaluate(() => {
+      const gls = (window as any).__capturedGLs as WebGLRenderingContext[];
+      if (gls.length === 0) throw new Error('No WebGL contexts were captured');
+
+      // The library creates its canvas once and caches it; that context will
+      // be the last (or only) entry in __capturedGLs after the first tm.get().
+      const lastGL = gls[gls.length - 1];
+      const ext = lastGL.getExtension('WEBGL_lose_context');
+      if (!ext) throw new Error('WEBGL_lose_context extension not available in this browser/environment');
+      ext.loseContext();
+    });
+
+    // Give the browser a tick to fire and propagate the webglcontextlost event
+    await page.waitForTimeout(50);
+
+    // -----------------------------------------------------------------------
+    // Second tm.get() — library must rebuild from scratch
+    // -----------------------------------------------------------------------
+    const result2 = await page.evaluate(async () => {
+      // @ts-ignore
+      const tm = new ThumbmarkJS.Thumbmark();
+      const data = await tm.get({ exclude: ['speech'] });
+      return {
+        thumbmark: data.thumbmark as string,
+        commonPixelsHash: (data.components?.webgl as any)?.commonPixelsHash as string | undefined,
+      };
+    });
+
+    // -----------------------------------------------------------------------
+    // Assertions
+    // -----------------------------------------------------------------------
+
+    // WebGL recovered and produced a real hash (not 'unsupported')
+    expect(result2.commonPixelsHash).toBeDefined();
+    expect(result2.commonPixelsHash).not.toBe('unsupported');
+
+    // The fingerprint is stable across context loss + rebuild
+    expect(result2.thumbmark).toBe(result1.thumbmark);
+
+    // The webgl sub-hash is also identical
+    expect(result2.commonPixelsHash).toBe(result1.commonPixelsHash);
+
+    // Rebuilding created at least one additional GL context, confirming that
+    // the library did not silently reuse the lost (invalid) context.
+    const capturedCount = await page.evaluate(() => {
+      return ((window as any).__capturedGLs as WebGLRenderingContext[]).length;
+    });
+    expect(capturedCount).toBeGreaterThan(1);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thumbmarkjs/thumbmarkjs",
-  "version": "1.7.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thumbmarkjs/thumbmarkjs",
-      "version": "1.7.1",
+      "version": "1.8.2",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thumbmarkjs/thumbmarkjs",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "",
   "type": "module",
   "main": "./dist/thumbmark.cjs.js",

--- a/src/components/audio/index.ts
+++ b/src/components/audio/index.ts
@@ -51,7 +51,6 @@ async function createAudioFingerprint(): Promise<componentInterface> {
       
   
     } catch (error) {
-      console.error('Error creating audio fingerprint:', error);
       reject(error);
     }
   

--- a/src/components/system/browser.ts
+++ b/src/components/system/browser.ts
@@ -10,6 +10,15 @@ interface BrowserDetectionStrategy {
   detect: () => boolean;
 }
 
+// Module-scoped cache keyed on brave-marker + UA string.
+// Brave masks its UA so we must distinguish brave vs non-brave for the same UA.
+const browserCache = new Map<string, BrowserResult>();
+
+/** Test-only: reset the memoization cache between test runs. */
+export function __resetBrowserCache(): void {
+  browserCache.clear();
+}
+
 // Define a function to parse the user agent string and return the browser name and version
 export function getBrowser(): BrowserResult {
   if (typeof navigator === 'undefined') {
@@ -19,23 +28,34 @@ export function getBrowser(): BrowserResult {
     }
   }
 
+  const isBrave = !!(navigator as any).brave;
+  const cacheKey = (isBrave ? 'B|' : 'N|') + navigator.userAgent;
+  const cached = browserCache.get(cacheKey);
+  if (cached) return cached;
+
   // Check for privacy browsers first (these mask their user agent)
   const privacyBrowserStrategies: BrowserDetectionStrategy[] = [
     {
       name: 'Brave',
-      detect: () => !!(navigator as any).brave
+      detect: () => isBrave
     }
   ];
 
+  let result: BrowserResult;
+
   for (const strategy of privacyBrowserStrategies) {
     if (strategy.detect()) {
-      const result = parseBrowserFromUA(navigator.userAgent);
-      return { name: strategy.name, version: result.version };
+      const parsed = parseBrowserFromUA(navigator.userAgent);
+      result = { name: strategy.name, version: parsed.version };
+      browserCache.set(cacheKey, result);
+      return result;
     }
   }
 
   // Fall back to user agent parsing for standard browsers
-  return parseBrowserFromUA(navigator.userAgent);
+  result = parseBrowserFromUA(navigator.userAgent);
+  browserCache.set(cacheKey, result);
+  return result;
 }
 
 // Parse browser from user agent string

--- a/src/components/webgl/index.test.ts
+++ b/src/components/webgl/index.test.ts
@@ -1,0 +1,223 @@
+import getWebGL, { __resetWebGLCache, __getWebGLCache } from './index';
+
+// ---------------------------------------------------------------------------
+// Mock ImageData — jsdom does not provide a real implementation
+// ---------------------------------------------------------------------------
+class MockImageData {
+    data: Uint8ClampedArray;
+    width: number;
+    height: number;
+
+    constructor(dataOrWidth: Uint8ClampedArray | number, widthOrUndefined?: number, height?: number) {
+        if (dataOrWidth instanceof Uint8ClampedArray) {
+            this.data = dataOrWidth;
+            this.width = widthOrUndefined ?? 1;
+            this.height = height ?? 1;
+        } else {
+            const w = dataOrWidth as number;
+            const h = widthOrUndefined ?? 1;
+            this.data = new Uint8ClampedArray(w * h * 4);
+            this.width = w;
+            this.height = h;
+        }
+    }
+}
+(global as any).ImageData = MockImageData;
+
+// ---------------------------------------------------------------------------
+// WebGL mock factory — returns an object satisfying setupWebGL() and renderImage()
+// ---------------------------------------------------------------------------
+function makeGlMock(overrides: Partial<WebGLRenderingContext> = {}): WebGLRenderingContext {
+    const gl: any = {
+        VERTEX_SHADER: 35633,
+        FRAGMENT_SHADER: 35632,
+        ARRAY_BUFFER: 34962,
+        COMPILE_STATUS: 35713,
+        LINK_STATUS: 35714,
+        RGBA: 6408,
+        UNSIGNED_BYTE: 5121,
+        COLOR_BUFFER_BIT: 16384,
+        FLOAT: 5126,
+        LINES: 1,
+        drawingBufferWidth: 200,
+        drawingBufferHeight: 100,
+        createShader: jest.fn().mockReturnValue({}),
+        shaderSource: jest.fn(),
+        compileShader: jest.fn(),
+        getShaderParameter: jest.fn().mockReturnValue(true),
+        createProgram: jest.fn().mockReturnValue({}),
+        attachShader: jest.fn(),
+        linkProgram: jest.fn(),
+        getProgramParameter: jest.fn().mockReturnValue(true),
+        createBuffer: jest.fn().mockReturnValue({}),
+        bindBuffer: jest.fn(),
+        bufferData: jest.fn(),
+        useProgram: jest.fn(),
+        getAttribLocation: jest.fn().mockReturnValue(0),
+        enableVertexAttribArray: jest.fn(),
+        vertexAttribPointer: jest.fn(),
+        viewport: jest.fn(),
+        clearColor: jest.fn(),
+        clear: jest.fn(),
+        drawArrays: jest.fn(),
+        readPixels: jest.fn(),
+        ...overrides,
+    };
+    return gl as WebGLRenderingContext;
+}
+
+// ---------------------------------------------------------------------------
+// Suite setup
+// ---------------------------------------------------------------------------
+let originalGetContext: any;
+
+beforeAll(() => {
+    originalGetContext = HTMLCanvasElement.prototype.getContext;
+});
+
+afterAll(() => {
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+});
+
+beforeEach(() => {
+    __resetWebGLCache();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('webgl component — context-loss recovery', () => {
+
+    // Happy path: cache is populated after first successful call
+    test('first getWebGL() call populates the cache', async () => {
+        HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue(makeGlMock()) as any;
+
+        await getWebGL();
+
+        expect(__getWebGLCache()).not.toBeNull();
+    });
+
+    // Cache reuse: two calls share the same canvas object
+    test('two consecutive getWebGL() calls reuse the same cached canvas', async () => {
+        HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue(makeGlMock()) as any;
+
+        await getWebGL();
+        const cacheAfterFirst = __getWebGLCache();
+        expect(cacheAfterFirst).not.toBeNull();
+
+        await getWebGL();
+        const cacheAfterSecond = __getWebGLCache();
+
+        // Same object reference — no new canvas was created
+        expect(cacheAfterSecond).toBe(cacheAfterFirst);
+        // getContext called exactly once (canvas created once)
+        expect(HTMLCanvasElement.prototype.getContext).toHaveBeenCalledTimes(1);
+    });
+
+    // Context-loss listener: dispatching webglcontextlost clears the cache
+    test('webglcontextlost event clears the cache', async () => {
+        HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue(makeGlMock()) as any;
+
+        await getWebGL();
+        const cacheBeforeLoss = __getWebGLCache();
+        expect(cacheBeforeLoss).not.toBeNull();
+
+        // Fire the context-lost event on the cached canvas
+        cacheBeforeLoss!.canvas.dispatchEvent(new Event('webglcontextlost', { cancelable: true }));
+
+        expect(__getWebGLCache()).toBeNull();
+    });
+
+    // Context-loss listener: event.preventDefault() is called
+    test('webglcontextlost listener calls event.preventDefault()', async () => {
+        HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue(makeGlMock()) as any;
+
+        await getWebGL();
+        const cache = __getWebGLCache();
+        expect(cache).not.toBeNull();
+
+        const lostEvent = new Event('webglcontextlost', { cancelable: true });
+        const preventDefaultSpy = jest.spyOn(lostEvent, 'preventDefault');
+
+        cache!.canvas.dispatchEvent(lostEvent);
+
+        expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // After context loss, next getWebGL() call creates a NEW canvas
+    test('getWebGL() after context loss rebuilds the cache via a new canvas', async () => {
+        const gl = makeGlMock();
+        HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue(gl) as any;
+
+        await getWebGL();
+        const firstCache = __getWebGLCache();
+        expect(firstCache).not.toBeNull();
+
+        // Simulate context loss
+        firstCache!.canvas.dispatchEvent(new Event('webglcontextlost', { cancelable: true }));
+        expect(__getWebGLCache()).toBeNull();
+
+        // Reset mock call count, re-install for rebuild
+        HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue(gl) as any;
+
+        await getWebGL();
+        const secondCache = __getWebGLCache();
+        expect(secondCache).not.toBeNull();
+        // A fresh cache object is created — different reference from the lost one
+        expect(secondCache).not.toBe(firstCache);
+        // getContext called once for the rebuild (new canvas)
+        expect(HTMLCanvasElement.prototype.getContext).toHaveBeenCalledTimes(1);
+    });
+
+    // once: true — the listener fires at most once per canvas
+    test('webglcontextlost listener fires only once (once:true)', async () => {
+        HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue(makeGlMock()) as any;
+
+        await getWebGL();
+        const firstCache = __getWebGLCache();
+        const canvas = firstCache!.canvas;
+
+        // First dispatch: clears cache
+        canvas.dispatchEvent(new Event('webglcontextlost', { cancelable: true }));
+        expect(__getWebGLCache()).toBeNull();
+
+        // Second dispatch on the same canvas — listener already removed (once:true),
+        // so _cache remains null (unchanged) and no throw occurs
+        expect(() => {
+            canvas.dispatchEvent(new Event('webglcontextlost', { cancelable: true }));
+        }).not.toThrow();
+        expect(__getWebGLCache()).toBeNull();
+    });
+
+    // renderImage catch block: render failure clears the cache
+    test('render failure (useProgram throws) clears the cache', async () => {
+        HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue(makeGlMock()) as any;
+
+        // First call populates cache
+        await getWebGL();
+        expect(__getWebGLCache()).not.toBeNull();
+
+        // Patch the cached gl to throw on the next render
+        const cache = __getWebGLCache()!;
+        (cache as any).gl.useProgram = jest.fn().mockImplementation(() => {
+            throw new Error('WebGL context lost');
+        });
+
+        // The call should not throw; it should return the 'unsupported' fallback
+        const result = await getWebGL();
+        expect(result).toEqual({ webgl: 'unsupported' });
+
+        // Cache must have been cleared by the catch block
+        expect(__getWebGLCache()).toBeNull();
+    });
+
+    // Graceful degradation: getContext returns null → returns 'unsupported'
+    test('getWebGL() returns unsupported when WebGL context is unavailable', async () => {
+        HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue(null) as any;
+
+        const result = await getWebGL();
+
+        expect(result).toEqual({ webgl: 'unsupported' });
+        expect(__getWebGLCache()).toBeNull();
+    });
+});

--- a/src/components/webgl/index.ts
+++ b/src/components/webgl/index.ts
@@ -1,146 +1,166 @@
-import { componentInterface, includeComponent } from '../../factory'
+import { componentInterface } from '../../factory'
 import { hash } from '../../utils/hash'
 import { getCommonPixels } from '../../utils/commonPixels';
 import { getBrowser } from '../system/browser';
 
 const _RUNS = (getBrowser().name !== 'SamsungBrowser') ? 1 : 3;
-let canvas: HTMLCanvasElement
-let gl: WebGLRenderingContext | null = null;
+const _USE_CACHE = getBrowser().name !== 'Brave';
 
-function initializeCanvasAndWebGL() {
-  if (typeof document !== 'undefined') {
-    canvas = document.createElement('canvas');
-    canvas.width = 200;
-    canvas.height = 100;
-    gl = canvas.getContext('webgl');
-  }
+// Canvas and viewport dimensions — part of the fingerprint signal, do not change.
+const _CANVAS_W = 200;
+const _CANVAS_H = 100;
+const _NUM_SPOKES = 137;
+
+// Shader sources are constant — hoist to module scope to avoid per-call string allocation.
+const _VERTEX_SHADER_SRC = `
+    attribute vec2 position;
+    void main() {
+        gl_Position = vec4(position, 0.0, 1.0);
+    }
+`;
+
+const _FRAGMENT_SHADER_SRC = `
+    precision mediump float;
+    void main() {
+        gl_FragColor = vec4(0.812, 0.195, 0.553, 0.921); // Set line color
+    }
+`;
+
+// Precompute the spoke vertices once at module load. The values are determined
+// solely by _NUM_SPOKES, _CANVAS_W, and _CANVAS_H — all module constants —
+// so they are identical to what the old per-call computation produced.
+const _VERTICES: Float32Array = (() => {
+    const v = new Float32Array(_NUM_SPOKES * 4);
+    const angleIncrement = (2 * Math.PI) / _NUM_SPOKES;
+    for (let i = 0; i < _NUM_SPOKES; i++) {
+        const angle = i * angleIncrement;
+        v[i * 4]     = 0;                                  // Center X
+        v[i * 4 + 1] = 0;                                  // Center Y
+        v[i * 4 + 2] = Math.cos(angle) * (_CANVAS_W / 2); // Endpoint X
+        v[i * 4 + 3] = Math.sin(angle) * (_CANVAS_H / 2); // Endpoint Y
+    }
+    return v;
+})();
+
+interface WebGLCache {
+    canvas: HTMLCanvasElement;
+    gl: WebGLRenderingContext;
+    program: WebGLProgram;
+    buffer: WebGLBuffer;
+}
+
+// Module-scope cache — only populated when _USE_CACHE is true (non-Brave).
+let _cache: WebGLCache | null = null;
+
+/**
+ * Create a canvas, compile shaders, link program, and upload vertex data.
+ * Returns null if any step fails so callers can degrade gracefully.
+ */
+function setupWebGL(): WebGLCache | null {
+    try {
+        if (typeof document === 'undefined') return null;
+
+        const canvas = document.createElement('canvas');
+        canvas.width = _CANVAS_W;
+        canvas.height = _CANVAS_H;
+
+        const gl = canvas.getContext('webgl');
+        if (!gl) return null;
+
+        const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+        const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+        if (!vertexShader || !fragmentShader) return null;
+
+        gl.shaderSource(vertexShader, _VERTEX_SHADER_SRC);
+        gl.compileShader(vertexShader);
+        if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) return null;
+
+        gl.shaderSource(fragmentShader, _FRAGMENT_SHADER_SRC);
+        gl.compileShader(fragmentShader);
+        if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) return null;
+
+        const program = gl.createProgram();
+        if (!program) return null;
+
+        gl.attachShader(program, vertexShader);
+        gl.attachShader(program, fragmentShader);
+        gl.linkProgram(program);
+        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) return null;
+
+        const buffer = gl.createBuffer();
+        if (!buffer) return null;
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+        gl.bufferData(gl.ARRAY_BUFFER, _VERTICES, gl.STATIC_DRAW);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+        return { canvas, gl, program, buffer };
+    } catch (_) {
+        return null;
+    }
+}
+
+/**
+ * For non-Brave browsers: lazily initialise once and reuse.
+ * For Brave: always create fresh (Brave farbles WebGL per-context, preserving
+ * the noise signal that today's per-call setup drives).
+ */
+function getOrInitCache(): WebGLCache | null {
+    if (_USE_CACHE) {
+        if (!_cache) _cache = setupWebGL();
+        return _cache;
+    }
+    // Brave path: fresh context every call, byte-identical behaviour to pre-cache code.
+    return setupWebGL();
+}
+
+/**
+ * Execute one render pass on the shared (or fresh) WebGL context and return
+ * the raw pixel data as an ImageData. Returns a 1×1 blank ImageData on error.
+ */
+function renderImage(cache: WebGLCache): ImageData {
+    const { canvas, gl, program, buffer } = cache;
+    try {
+        gl.useProgram(program);
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+
+        const positionAttribute = gl.getAttribLocation(program, 'position');
+        gl.enableVertexAttribArray(positionAttribute);
+        gl.vertexAttribPointer(positionAttribute, 2, gl.FLOAT, false, 0, 0);
+
+        gl.viewport(0, 0, canvas.width, canvas.height);
+        gl.clearColor(0.0, 0.0, 0.0, 1.0);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.drawArrays(gl.LINES, 0, _NUM_SPOKES * 2);
+
+        const pixelData = new Uint8ClampedArray(canvas.width * canvas.height * 4);
+        gl.readPixels(0, 0, canvas.width, canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, pixelData);
+        return new ImageData(pixelData, canvas.width, canvas.height);
+    } catch (_) {
+        return new ImageData(1, 1);
+    } finally {
+        // Reset WebGL state to match pre-cache behaviour.
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        gl.useProgram(null);
+        gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+        gl.clearColor(0.0, 0.0, 0.0, 0.0);
+    }
 }
 
 export default async function getWebGL(): Promise<componentInterface> {
-  initializeCanvasAndWebGL();
-  
-  try {
+    const cache = getOrInitCache();
 
-    if (!gl) {
-        throw new Error('WebGL not supported');
+    if (!cache) {
+        return { 'webgl': 'unsupported' };
     }
 
-
-    const imageDatas: ImageData[] = Array.from({length: _RUNS}, () => createWebGLImageData() );
-    // and then checking the most common bytes for each channel of each pixel
-    const commonImageData = getCommonPixels(imageDatas, canvas.width, canvas.height);
-    //const imageData = createWebGLImageData()
-
-    return {
-      'commonPixelsHash': hash(commonImageData.data.toString()).toString(),
+    try {
+        const imageDatas: ImageData[] = Array.from({ length: _RUNS }, () => renderImage(cache));
+        const commonImageData = getCommonPixels(imageDatas, cache.canvas.width, cache.canvas.height);
+        return {
+            'commonPixelsHash': hash(commonImageData.data.toString()).toString(),
+        };
+    } catch (_) {
+        return { 'webgl': 'unsupported' };
     }
-  } catch (error) {
-    return {
-      'webgl': 'unsupported'
-    }
-  }
-}
-
-function createWebGLImageData(): ImageData {
-  try {
-
-      if (!gl) {
-          throw new Error('WebGL not supported');
-      }
-
-      const vertexShaderSource = `
-          attribute vec2 position;
-          void main() {
-              gl_Position = vec4(position, 0.0, 1.0);
-          }
-      `;
-
-      const fragmentShaderSource = `
-          precision mediump float;
-          void main() {
-              gl_FragColor = vec4(0.812, 0.195, 0.553, 0.921); // Set line color
-          }
-      `;
-
-      const vertexShader = gl.createShader(gl.VERTEX_SHADER);
-      const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
-
-      if (!vertexShader || !fragmentShader) {
-          throw new Error('Failed to create shaders');
-      }
-
-      gl.shaderSource(vertexShader, vertexShaderSource);
-      gl.shaderSource(fragmentShader, fragmentShaderSource);
-
-      gl.compileShader(vertexShader);
-      if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
-          throw new Error('Vertex shader compilation failed: ' + gl.getShaderInfoLog(vertexShader));
-      }
-
-      gl.compileShader(fragmentShader);
-      if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
-          throw new Error('Fragment shader compilation failed: ' + gl.getShaderInfoLog(fragmentShader));
-      }
-
-      const shaderProgram = gl.createProgram();
-
-      if (!shaderProgram) {
-          throw new Error('Failed to create shader program');
-      }
-
-      gl.attachShader(shaderProgram, vertexShader);
-      gl.attachShader(shaderProgram, fragmentShader);
-      gl.linkProgram(shaderProgram);
-      if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
-          throw new Error('Shader program linking failed: ' + gl.getProgramInfoLog(shaderProgram));
-      }
-
-      gl.useProgram(shaderProgram);
-
-      // Set up vertices to form lines
-      const numSpokes: number = 137;
-      const vertices = new Float32Array(numSpokes * 4);
-      const angleIncrement = (2 * Math.PI) / numSpokes;
-
-      for (let i = 0; i < numSpokes; i++) {
-          const angle = i * angleIncrement;
-
-          // Define two points for each line (spoke)
-          vertices[i * 4] = 0; // Center X
-          vertices[i * 4 + 1] = 0; // Center Y
-          vertices[i * 4 + 2] = Math.cos(angle) * (canvas.width / 2); // Endpoint X
-          vertices[i * 4 + 3] = Math.sin(angle) * (canvas.height / 2); // Endpoint Y
-      }
-
-      const vertexBuffer = gl.createBuffer();
-      gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-      gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
-
-      const positionAttribute = gl.getAttribLocation(shaderProgram, 'position');
-      gl.enableVertexAttribArray(positionAttribute);
-      gl.vertexAttribPointer(positionAttribute, 2, gl.FLOAT, false, 0, 0);
-
-      // Render
-      gl.viewport(0, 0, canvas.width, canvas.height);
-      gl.clearColor(0.0, 0.0, 0.0, 1.0);
-      gl.clear(gl.COLOR_BUFFER_BIT);
-      gl.drawArrays(gl.LINES, 0, numSpokes * 2);
-
-      const pixelData = new Uint8ClampedArray(canvas.width * canvas.height * 4);
-      gl.readPixels(0, 0, canvas.width, canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, pixelData);
-      const imageData = new ImageData(pixelData, canvas.width, canvas.height);
-
-      return imageData;
-  } catch (error) {
-      //console.error(error);
-      return new ImageData(1, 1);
-  } finally {
-    if (gl) {
-      // Reset WebGL state
-      gl.bindBuffer(gl.ARRAY_BUFFER, null);
-      gl.useProgram(null);
-      gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-      gl.clearColor(0.0, 0.0, 0.0, 0.0);
-    }
-  }
 }

--- a/src/components/webgl/index.ts
+++ b/src/components/webgl/index.ts
@@ -52,6 +52,16 @@ interface WebGLCache {
 // Module-scope cache — only populated when _USE_CACHE is true (non-Brave).
 let _cache: WebGLCache | null = null;
 
+/** Test-only: reset the module-scope cache between test runs. */
+export function __resetWebGLCache(): void {
+    _cache = null;
+}
+
+/** Test-only: read the current cache reference without mutating it. */
+export function __getWebGLCache(): WebGLCache | null {
+    return _cache;
+}
+
 /**
  * Create a canvas, compile shaders, link program, and upload vertex data.
  * Returns null if any step fails so callers can degrade gracefully.
@@ -66,6 +76,15 @@ function setupWebGL(): WebGLCache | null {
 
         const gl = canvas.getContext('webgl');
         if (!gl) return null;
+
+        // When the browser invalidates GPU resources it fires webglcontextlost.
+        // Null the cache so the next getOrInitCache() rebuilds via a fresh setupWebGL().
+        // { once: true } ensures the listener self-removes after firing so the old
+        // canvas does not keep the WebGLCache object alive after recovery.
+        canvas.addEventListener('webglcontextlost', (event) => {
+            event.preventDefault();
+            _cache = null;
+        }, { once: true });
 
         const vertexShader = gl.createShader(gl.VERTEX_SHADER);
         const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
@@ -137,6 +156,9 @@ function renderImage(cache: WebGLCache): ImageData {
         gl.readPixels(0, 0, canvas.width, canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, pixelData);
         return new ImageData(pixelData, canvas.width, canvas.height);
     } catch (_) {
+        // Belt-and-suspenders: any render failure (context loss, GPU driver glitch, etc.)
+        // invalidates the cache so the next call rebuilds rather than retrying with a stale context.
+        _cache = null;
         return new ImageData(1, 1);
     } finally {
         // Reset WebGL state to match pre-cache behaviour.

--- a/src/components/webrtc/index.ts
+++ b/src/components/webrtc/index.ts
@@ -5,6 +5,7 @@ import { stableStringify } from '../../utils/stableStringify';
 
 export default async function getWebRTC(options?: optionsInterface): Promise<componentInterface | null> {
   return new Promise((resolve) => {
+    let connection: RTCPeerConnection | undefined;
     try {
       // Check if WebRTC is supported
       const RTCPeerConnection = (window as any).RTCPeerConnection || (window as any).webkitRTCPeerConnection || (window as any).mozRTCPeerConnection;
@@ -21,14 +22,17 @@ export default async function getWebRTC(options?: optionsInterface): Promise<com
         iceServers: []
       };
 
-      const connection = new RTCPeerConnection(config);
-      connection.createDataChannel(''); // trigger ICE gathering
+      connection = new RTCPeerConnection(config);
+      // Non-null assertion: connection was just assigned above; if the constructor
+      // had thrown we would not reach this line.
+      const conn: RTCPeerConnection = connection!;
+      conn.createDataChannel(''); // trigger ICE gathering
 
       const processOffer = async () => {
         try {
           const offerOptions = { offerToReceiveAudio: true, offerToReceiveVideo: true };
-          const offer = await connection.createOffer(offerOptions);
-          await connection.setLocalDescription(offer);
+          const offer = await conn.createOffer(offerOptions);
+          await conn.setLocalDescription(offer);
 
           const sdp = offer.sdp || '';
 
@@ -81,39 +85,11 @@ export default async function getWebRTC(options?: optionsInterface): Promise<com
             extensionsHash: hash(stableStringify(extensions))
           };
 
-          // Set up for ICE candidate collection with timeout
-          // Use 60% of the total timeout to ensure this completes before the global timeout
-          const totalTimeout = options?.timeout || 5000;
-          const iceTimeout = Math.floor(totalTimeout * 0.9);
-
-          const result = await new Promise<componentInterface>((resolveResult) => {
-            const timeout = setTimeout(() => {
-              connection.removeEventListener('icecandidate', onIceCandidate);
-              connection.close();
-              resolveResult({
-                supported: true,
-                ...compressedData,
-                timeout: true
-              });
-            }, iceTimeout);
-
-            const onIceCandidate = (event: RTCPeerConnectionIceEvent) => {
-              const candidateObj = event.candidate;
-              if (!candidateObj || !candidateObj.candidate) return;
-
-              clearTimeout(timeout);
-              connection.removeEventListener('icecandidate', onIceCandidate);
-              connection.close();
-
-              resolveResult({
-                supported: true,
-                ...compressedData,
-                candidateType: candidateObj.type || ''
-              });
-            };
-
-            connection.addEventListener('icecandidate', onIceCandidate);
-          });
+          // With iceServers:[] only "host" candidates are generated, so waiting for
+          // the icecandidate event adds latency without any entropy gain. Close
+          // immediately and hard-code the known value to keep the hash stable.
+          conn.close();
+          const result = { supported: true, ...compressedData, candidateType: 'host' };
 
           resolve({
             details: result,
@@ -121,7 +97,7 @@ export default async function getWebRTC(options?: optionsInterface): Promise<com
           });
 
         } catch (error) {
-          connection.close();
+          conn.close();
           resolve({
             supported: true,
             error: `WebRTC offer failed: ${(error as Error).message}`
@@ -132,6 +108,7 @@ export default async function getWebRTC(options?: optionsInterface): Promise<com
       processOffer();
 
     } catch (error) {
+      connection?.close();
       resolve({
         supported: false,
         error: `WebRTC error: ${(error as Error).message}`

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -91,16 +91,18 @@ export async function getThumbmark(
       ...customComponents,
       ...instanceCustomComponents,
     } as Record<string, componentFunctionInterface>;
-    const { elapsed, resolvedComponents: clientComponentsResult, errors: componentErrors } = await resolveClientComponents(allComponents, _options);
+    const { elapsed, resolvedComponents: clientComponentsResult, errors: componentErrors, pipelineTimings: mainPipelineTimings } = await resolveClientComponents(allComponents, _options);
     allErrors.push(...componentErrors);
 
     // Resolve experimental components only when logging
     let experimentalComponents = {};
     let experimentalElapsed = {};
+    let expPipelineTimings: Record<string, number> = {};
     if (shouldLog || _options.experimental) {
-      const { elapsed: expElapsed, resolvedComponents, errors: expErrors } = await resolveClientComponents(tm_experimental_component_promises, _options);
+      const { elapsed: expElapsed, resolvedComponents, errors: expErrors, pipelineTimings: expTimings } = await resolveClientComponents(tm_experimental_component_promises, _options);
       experimentalComponents = resolvedComponents;
       experimentalElapsed = expElapsed;
+      expPipelineTimings = expTimings;
       allErrors.push(...expErrors);
     }
 
@@ -132,15 +134,29 @@ export async function getThumbmark(
       allErrors.push({ type: 'api_timeout', message: 'API request timed out' });
     }
 
-    // Only add 'elapsed' if performance is true
-    const allElapsed = { ...elapsed, ...experimentalElapsed };
-    const maybeElapsed = _options.performance ? { elapsed: allElapsed } : {};
+    const filterStart = performance.now();
     const apiComponents = filterThumbmarkData(apiResult?.components || {}, _options);
+    const filterMs = performance.now() - filterStart;
+
     const components = { ...clientComponentsResult, ...apiComponents };
     const info: infoInterface = apiResult?.info || { uniqueness: { score: 'api only' } };
 
     // Use API thumbmark if available to ensure API/client sync, otherwise calculate locally
-    const thumbmark = apiResult?.thumbmark ?? hash(stableStringify(components));
+    let thumbmark: string;
+    let stringifyMs = 0;
+    let hashMs = 0;
+    if (apiResult?.thumbmark) {
+      thumbmark = apiResult.thumbmark;
+    } else {
+      const stringifyStart = performance.now();
+      const stringified = stableStringify(components);
+      stringifyMs = performance.now() - stringifyStart;
+
+      const hashStart = performance.now();
+      thumbmark = hash(stringified);
+      hashMs = performance.now() - hashStart;
+    }
+
     const version = getVersion();
 
     // Only log to server when not in debug mode
@@ -148,6 +164,26 @@ export async function getThumbmark(
       logThumbmarkData(thumbmark, components, _options, experimentalComponents, allErrors).catch(() => { /* do nothing */ });
     }
 
+    // Accumulate _pipeline timings from both the main and (if run) experimental component phases.
+    // Filter time includes: main component filter + optional experimental filter + apiComponents filter.
+    const expFilterMs = expPipelineTimings['_pipeline.filter'] ?? 0;
+    const _pipelineTimings: Record<string, number> = {
+      '_pipeline.dispatch': mainPipelineTimings['_pipeline.dispatch'],
+      '_pipeline.resolve': mainPipelineTimings['_pipeline.resolve'],
+      '_pipeline.filter': mainPipelineTimings['_pipeline.filter'] + expFilterMs + filterMs,
+      '_pipeline.stringify': stringifyMs,
+      '_pipeline.hash': hashMs,
+      '_pipeline.assembly': 0, // placeholder, updated below after result construction
+    };
+
+    // Only add 'elapsed' if performance is true
+    // allElapsed holds a live reference to _pipelineTimings entries via spread — we update assembly after.
+    // mainPipelineTimings contains both _pipeline.* keys (overridden by _pipelineTimings below) and
+    // _dispatch.<name> keys (per-component sync prelude timings) that flow through unchanged.
+    const allElapsed: Record<string, number> = { ...elapsed, ...experimentalElapsed, ...mainPipelineTimings, ..._pipelineTimings };
+    const maybeElapsed = _options.performance ? { elapsed: allElapsed } : {};
+
+    const assemblyStart = performance.now();
     const result: ThumbmarkResponse = {
       ...(apiResult?.visitorId && { visitorId: apiResult.visitorId }),
       thumbmark,
@@ -160,6 +196,8 @@ export async function getThumbmark(
       ...(apiResult?.requestId && { requestId: apiResult.requestId }),
       ...(apiResult?.metadata && { metadata: apiResult.metadata }),
     };
+    // Update assembly timing in allElapsed directly (allElapsed is the same object referenced by result.elapsed).
+    allElapsed['_pipeline.assembly'] = performance.now() - assemblyStart;
 
     return result;
   } catch (e) {
@@ -180,12 +218,12 @@ export async function getThumbmark(
  *
  * @param comps - Map of component functions
  * @param options - Options for filtering and timing
- * @returns Object with elapsed times and filtered resolved components
+ * @returns Object with elapsed times, filtered resolved components, errors, and pipeline phase timings
  */
 export async function resolveClientComponents(
   comps: { [key: string]: (options?: optionsInterface) => Promise<componentInterface | null> },
   options?: optionsInterface
-): Promise<{ elapsed: Record<string, number>, resolvedComponents: componentInterface, errors: ThumbmarkError[] }> {
+): Promise<{ elapsed: Record<string, number>, resolvedComponents: componentInterface, errors: ThumbmarkError[], pipelineTimings: Record<string, number> }> {
   const opts = { ...defaultOptions, ...options };
   const topLevelExcludes = getExcludeList(opts).filter(e => !e.includes('.'));
   const filtered = Object.entries(comps)
@@ -197,8 +235,20 @@ export async function resolveClientComponents(
         : opts?.include?.length === 0 || opts?.include?.includes(key)
     );
   const keys = filtered.map(([key]) => key);
-  const promises = filtered.map(([_, fn]) => fn(options));
+
+  const perComponentDispatch: Record<string, number> = {};
+  const dispatchStart = performance.now();
+  const promises = filtered.map(([key, fn]) => {
+    const t0 = performance.now();
+    const p = fn(options);
+    perComponentDispatch[`_dispatch.${key}`] = performance.now() - t0;
+    return p;
+  });
+  const dispatchMs = performance.now() - dispatchStart;
+
+  const resolveStart = performance.now();
   const resolvedValues = await raceAllPerformance(promises, opts?.timeout || 5000, timeoutInstance);
+  const resolveMs = performance.now() - resolveStart;
 
   const elapsed: Record<string, number> = {};
   const resolvedComponentsRaw: Record<string, componentInterface> = {};
@@ -219,8 +269,18 @@ export async function resolveClientComponents(
     }
   });
 
+  const filterStart = performance.now();
   const resolvedComponents = filterThumbmarkData(resolvedComponentsRaw, opts);
-  return { elapsed, resolvedComponents, errors };
+  const filterMs = performance.now() - filterStart;
+
+  const pipelineTimings: Record<string, number> = {
+    '_pipeline.dispatch': dispatchMs,
+    '_pipeline.resolve': resolveMs,
+    '_pipeline.filter': filterMs,
+    ...perComponentDispatch,
+  };
+
+  return { elapsed, resolvedComponents, errors, pipelineTimings };
 }
 
 export { globalIncludeComponent as includeComponent };

--- a/src/utils/commonPixels.ts
+++ b/src/utils/commonPixels.ts
@@ -1,4 +1,29 @@
 export function getCommonPixels(images: ImageData[], width: number, height: number ): ImageData {
+    // Short-circuit: single image — every byte is trivially its own mode.
+    if (images.length === 1) {
+        return images[0];
+    }
+
+    // Fast path: exactly 3 images — inline 3-way comparison that mirrors
+    // getMostFrequent's tie-breaking exactly for all 5 value-combination cases:
+    //   all-equal → that value
+    //   a===b     → a (freq 2)
+    //   a===c     → a (freq 2)
+    //   b===c     → b (freq 2)
+    //   all-diff  → a (mostFrequent stays arr[0], no key beats freq 1)
+    if (images.length === 3) {
+        const a = images[0].data;
+        const b = images[1].data;
+        const c = images[2].data;
+        const out = new Uint8ClampedArray(a.length);
+        for (let i = 0; i < a.length; i++) {
+            const x = a[i], y = b[i], z = c[i];
+            out[i] = (x === y) ? x : (x === z) ? x : (y === z) ? y : x;
+        }
+        return new ImageData(out, width, height);
+    }
+
+    // Generic fallback for any other length (no current caller uses this path).
     let finalData: number[] = [];
     for (let i = 0; i < images[0].data.length; i++) {
         let indice: number[] = [];

--- a/src/utils/raceAll.ts
+++ b/src/utils/raceAll.ts
@@ -21,21 +21,31 @@ export function raceAllPerformance<T>(
   return Promise.all(
     promises.map((p) => {
       const startTime = performance.now();
-      return Promise.race([
-        p.then((value) => ({
-          value,
-          elapsed: performance.now() - startTime,
-        })).catch((err: unknown) => ({
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+      const resultPromise = p.then((value) => {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        return { value, elapsed: performance.now() - startTime };
+      }).catch((err: unknown) => {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        return {
           value: timeoutVal,
           elapsed: performance.now() - startTime,
           error: err instanceof Error ? err.message : String(err),
-        })),
-        delay(timeoutTime, timeoutVal).then((value) => ({
-          value,
-          elapsed: performance.now() - startTime,
-          error: 'timeout' as string,
-        })),
-      ]);
+        };
+      });
+
+      const timeoutPromise = new Promise<RaceResult<T>>((resolve) => {
+        timeoutId = setTimeout(() => {
+          resolve({
+            value: timeoutVal,
+            elapsed: performance.now() - startTime,
+            error: 'timeout',
+          });
+        }, timeoutTime);
+      });
+
+      return Promise.race([resultPromise, timeoutPromise]);
     })
   );
 }

--- a/src/utils/stableStringify.ts
+++ b/src/utils/stableStringify.ts
@@ -22,7 +22,9 @@
  */
 export function stableStringify(data: any): string {
 
-    const seen: any[] = [];
+    // Use a Set for O(1) cycle detection instead of O(N) array indexOf.
+    // The serialisation logic (key sorting, value recursion, output format) is unchanged.
+    const seen = new Set<any>();
 
     return (function stringify(node: any): string | undefined {
         if (node && node.toJSON && typeof node.toJSON === 'function') {
@@ -47,11 +49,11 @@ export function stableStringify(data: any): string {
 
         if (node === null) return 'null';
 
-        if (seen.indexOf(node) !== -1) {
+        if (seen.has(node)) {
             throw new TypeError('Converting circular structure to JSON');
         }
 
-        const seenIndex = seen.push(node) - 1;
+        seen.add(node);
         const keys = Object.keys(node).sort();
         out = '';
 
@@ -64,7 +66,7 @@ export function stableStringify(data: any): string {
             out += JSON.stringify(key) + ':' + value;
         }
 
-        seen.splice(seenIndex, 1);
+        seen.delete(node);
         return '{' + out + '}';
     })(data) || '';
 }

--- a/test.html
+++ b/test.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>thumbmarkjs — local perf harness</title>
+<style>
+  body { font: 14px/1.45 -apple-system, system-ui, sans-serif; margin: 24px; color: #222; max-width: 920px; }
+  h1   { font-size: 18px; margin: 0 0 4px; }
+  .sub { color: #666; margin-bottom: 16px; word-break: break-all; }
+  .hint { background: #fff8e1; border-left: 3px solid #f5a623; padding: 10px 12px; margin: 12px 0; border-radius: 0 4px 4px 0; }
+  .hint code { background: #fff3c4; padding: 1px 5px; border-radius: 3px; }
+  .controls { margin: 12px 0; }
+  .controls > * { margin-right: 6px; }
+  button, select { font: inherit; padding: 6px 10px; border: 1px solid #888; border-radius: 4px; background: #fff; cursor: pointer; }
+  button:hover, select:hover { background: #f0f0f0; }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+  label { margin-left: 12px; }
+  input[type=number] { width: 50px; }
+  input[type=text]   { width: 80px; }
+  table { border-collapse: collapse; margin-top: 12px; min-width: 640px; }
+  th, td { padding: 4px 10px; border-bottom: 1px solid #eee; text-align: right; }
+  th:first-child, td:first-child { text-align: left; }
+  tbody tr:hover { background: #fafafa; }
+  .total { font-weight: 600; background: #f5f5f5; }
+  pre  { background: #f7f7f7; padding: 10px; border-radius: 4px; overflow: auto; max-height: 300px; }
+  .ok   { color: #0a7d28; }
+  .err  { color: #b00020; }
+  .warn { color: #b06000; }
+  .src-local { color: #1a5fb4; font-weight: 600; }
+  .src-cdn   { color: #813d9c; font-weight: 600; }
+</style>
+</head>
+<body>
+  <h1>thumbmarkjs perf harness</h1>
+  <div class="sub" id="meta">Loading…</div>
+
+  <div class="hint">
+    <strong>To emulate a mid-tier Android device:</strong><br>
+    Open DevTools (<code>⌘⌥I</code> / <code>F12</code>) → <strong>Performance</strong> tab → <strong>CPU</strong> dropdown → choose
+    <code>4× slowdown</code> (mid-tier, Lighthouse default — Moto G4 class) or
+    <code>6× slowdown</code> (low-tier).<br>
+    Then click <strong>Re-run</strong> below. The DevTools setting persists across re-runs while DevTools stays open;
+    a full page reload also keeps it.
+  </div>
+
+  <div class="controls">
+    <label>Source:
+      <select id="source-select">
+        <option value="local">Local build (./dist)</option>
+        <option value="cdn">CDN (latest published)</option>
+      </select>
+    </label>
+    <button id="run">Re-run</button>
+    <label>Iterations: <input id="iters" type="number" min="1" max="100" value="5"></label>
+    <label>Warm-up: <input id="warmup" type="number" min="0" max="10" value="1"></label>
+    <label>CPU note: <input id="cpu-note" type="text" placeholder="e.g. 4x"></label>
+  </div>
+
+  <div id="status">Initializing…</div>
+  <div id="results"></div>
+  <h3>Raw last-run elapsed</h3>
+  <pre id="raw"></pre>
+
+<script>
+// ---- Source resolution ----
+const SOURCES = {
+  local: { url: './dist/thumbmark.umd.js',
+           label: 'local build (./dist/thumbmark.umd.js)',
+           cssClass: 'src-local' },
+  cdn:   { url: 'https://cdn.jsdelivr.net/npm/@thumbmarkjs/thumbmarkjs/dist/thumbmark.umd.js',
+           label: 'CDN — latest published @thumbmarkjs/thumbmarkjs',
+           cssClass: 'src-cdn' },
+};
+const params = new URLSearchParams(location.search);
+const sourceKey = params.get('source') === 'cdn' ? 'cdn' : 'local';
+const SOURCE = SOURCES[sourceKey];
+
+// ---- DOM refs ----
+const statusEl     = document.getElementById('status');
+const resultsEl    = document.getElementById('results');
+const rawEl        = document.getElementById('raw');
+const metaEl       = document.getElementById('meta');
+const runBtn       = document.getElementById('run');
+const itersIn      = document.getElementById('iters');
+const warmupIn     = document.getElementById('warmup');
+const cpuNote      = document.getElementById('cpu-note');
+const sourceSelect = document.getElementById('source-select');
+
+// ---- Source UI: sync dropdown to current state, change navigates ----
+sourceSelect.value = sourceKey;
+sourceSelect.addEventListener('change', (e) => {
+  const p = new URLSearchParams(location.search);
+  p.set('source', e.target.value);
+  location.search = p.toString();
+});
+
+metaEl.innerHTML = `Loading <span class="${SOURCE.cssClass}">${SOURCE.label}</span>…`;
+
+// Pre-fill cpu-note from ?cpu= query param if present.
+const qCpu = params.get('cpu');
+if (qCpu) cpuNote.value = qCpu;
+
+// ---- Helpers ----
+const median = (arr) => {
+  const s = [...arr].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+const fmt = (n) => n.toFixed(2);
+
+async function runHarness() {
+  if (typeof ThumbmarkJS === 'undefined') {
+    statusEl.innerHTML = `<span class="err">Failed: ThumbmarkJS UMD global not found. Source = ${SOURCE.url}</span>`;
+    return;
+  }
+  const ITERATIONS = Math.max(1, parseInt(itersIn.value, 10) || 5);
+  const WARMUP     = Math.max(0, parseInt(warmupIn.value, 10) || 0);
+  const noteTxt    = cpuNote.value.trim();
+
+  runBtn.disabled = true;
+  resultsEl.innerHTML = '';
+  rawEl.textContent = '';
+  statusEl.innerHTML = `<span class="warn">Running ${WARMUP} warm-up + ${ITERATIONS} measured iterations${noteTxt ? ' @ CPU '+noteTxt : ''} (source: <span class="${SOURCE.cssClass}">${sourceKey}</span>)…</span>`;
+
+  const tm = new ThumbmarkJS.Thumbmark({ performance: true });
+  metaEl.innerHTML = `<span class="${SOURCE.cssClass}">[${sourceKey}]</span> ${SOURCE.label} — version ${tm.getVersion()}${noteTxt ? ' — CPU note: '+noteTxt : ''}`;
+
+  for (let i = 0; i < WARMUP; i++) {
+    try { await tm.get(); } catch (e) {}
+  }
+
+  const runs = [];
+  for (let i = 0; i < ITERATIONS; i++) {
+    const t0 = performance.now();
+    let res;
+    try {
+      res = await tm.get();
+    } catch (e) {
+      statusEl.innerHTML = `<span class="err">Iteration ${i + 1} threw: ${e && e.message ? e.message : e}</span>`;
+      runBtn.disabled = false;
+      return;
+    }
+    const total = performance.now() - t0;
+    runs.push({ total, elapsed: res.elapsed || {}, thumbmark: res.thumbmark });
+  }
+
+  // Hash-stability sanity check across iterations
+  const distinctHashes = [...new Set(runs.map(r => r.thumbmark))];
+  if (distinctHashes.length > 1) {
+    console.warn('[thumbmarkjs perf] WARNING: thumbmark unstable across iterations:', distinctHashes);
+  }
+
+  const componentNames = new Set();
+  runs.forEach(r => Object.keys(r.elapsed).forEach(k => componentNames.add(k)));
+
+  const rows = [...componentNames].map(name => {
+    const samples = runs.map(r => r.elapsed[name] ?? 0);
+    return {
+      name,
+      median: median(samples),
+      min: Math.min(...samples),
+      max: Math.max(...samples),
+      samples,
+    };
+  }).sort((a, b) => b.median - a.median);
+
+  const totalMedian = median(runs.map(r => r.total));
+  const totalMin    = Math.min(...runs.map(r => r.total));
+  const totalMax    = Math.max(...runs.map(r => r.total));
+
+  let html = `
+    <table>
+      <thead>
+        <tr><th>Component</th><th>median (ms)</th><th>min</th><th>max</th><th>samples</th></tr>
+      </thead>
+      <tbody>
+        <tr class="total">
+          <td>TOTAL (tm.get wall-clock)</td>
+          <td>${fmt(totalMedian)}</td>
+          <td>${fmt(totalMin)}</td>
+          <td>${fmt(totalMax)}</td>
+          <td>${runs.map(r => fmt(r.total)).join(', ')}</td>
+        </tr>
+        ${rows.map(r => `
+          <tr>
+            <td>${r.name}</td>
+            <td>${fmt(r.median)}</td>
+            <td>${fmt(r.min)}</td>
+            <td>${fmt(r.max)}</td>
+            <td>${r.samples.map(fmt).join(', ')}</td>
+          </tr>
+        `).join('')}
+      </tbody>
+    </table>
+  `;
+  resultsEl.innerHTML = html;
+  statusEl.innerHTML = `<span class="ok">Done.</span> ${ITERATIONS} iterations after ${WARMUP} warm-up${noteTxt ? ' @ CPU '+noteTxt : ''} (source: <span class="${SOURCE.cssClass}">${sourceKey}</span>).`;
+  rawEl.textContent = JSON.stringify(runs[runs.length - 1].elapsed, null, 2);
+
+  console.log(`[thumbmarkjs perf] source=${sourceKey} version=${tm.getVersion()}${noteTxt ? ' CPU='+noteTxt : ''}`);
+  console.log('[thumbmarkjs perf] total median ms:', fmt(totalMedian));
+  console.log('[thumbmarkjs perf] thumbmark:', distinctHashes.length === 1 ? distinctHashes[0] : distinctHashes);
+  console.table(rows.map(r => ({
+    component: r.name,
+    median_ms: +fmt(r.median),
+    min_ms: +fmt(r.min),
+    max_ms: +fmt(r.max),
+  })));
+
+  // Encode results into document.title so external pollers (AppleScript) can
+  // read them without needing CDP / chrome-devtools MCP.
+  const titlePayload = {
+    source: sourceKey,
+    sourceUrl: SOURCE.url,
+    v: tm.getVersion(),
+    note: noteTxt || null,
+    iters: ITERATIONS,
+    warmup: WARMUP,
+    total: { median: +fmt(totalMedian), min: +fmt(totalMin), max: +fmt(totalMax) },
+    thumbmark: distinctHashes.length === 1 ? distinctHashes[0] : distinctHashes,
+    stable: distinctHashes.length === 1,
+    components: rows.map(r => ({
+      name: r.name,
+      median: +fmt(r.median),
+      min: +fmt(r.min),
+      max: +fmt(r.max),
+    })),
+  };
+  document.title = '__PERF__:' + JSON.stringify(titlePayload);
+
+  runBtn.disabled = false;
+}
+
+runBtn.addEventListener('click', runHarness);
+
+// ---- Load the chosen UMD build, then auto-run ----
+(function loadAndRun() {
+  const s = document.createElement('script');
+  s.src = SOURCE.url;
+  s.async = false;
+  s.onload = () => {
+    statusEl.textContent = 'Ready.';
+    runHarness();
+  };
+  s.onerror = () => {
+    statusEl.innerHTML = `<span class="err">Failed to load ${SOURCE.url}. ${
+      sourceKey === 'local'
+        ? 'Did you run <code>npm run build</code>?'
+        : 'Network error or CDN unreachable.'
+    }</span>`;
+  };
+  document.head.appendChild(s);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

This PR ships the 12-commit perf-optimization sweep authored by another contributor and verified by independent re-measurement + Samsung Internet hash equivalence test.

**Headline: ~4-5× faster `tm.get()` on Chromium**, with byte-identical fingerprint output (verified against published 1.8.1 on jsDelivr and against `main` directly).

## Verified perf numbers (Chromium via Playwright bench, 20 iter + 2 warmup)

| metric | main | this branch | delta |
|---|---:|---:|---:|
| local total mean | 120.6 ms | 20.9 ms | **-83%** |
| local total median | 117.7 ms | 19.6 ms | **-83%** |
| CPU-throttled (8×) total mean | ~620 ms | 144 ms | **-77%** |
| CPU-throttled (8×) total median | ~625 ms | 136 ms | **-78%** |

Per the optimization report, scaled to typical real-device throttling: mid-tier Android (Lighthouse 4× default) ~210 → ~67 ms; low-tier Android (6×) ~330 → ~100 ms.

## Hash equivalence proof

- **CDN-vs-local on Chromium (macOS):** published 1.8.1 from jsDelivr and the optimized local 1.8.1 produce byte-identical thumbmark `0ef8bdbc97de077c45a46358ecc4ba42` on the test machine.
- **main-vs-this-branch component-level diff (headless Chromium):** the 11 components touched by this branch produce byte-identical hashes. Speech component shows headless-Chrome timing flake (`voiceCount: 0` vs `68`) which is unrelated to this branch — same flake exists on `main` independently.
- **Samsung Internet via ../static A/B test page:** verified by the project owner. Hash equivalence holds.

## What's in the 12 commits

| commit | scope | win |
|---|---|---|
| `1dd10ac` | `perf(webrtc)`: drop ICE-candidate wait + fix resource leak | ~5 ms eliminated; hardcoded `candidateType: 'host'` (justified — `iceServers: []` produces only host candidates) |
| `af4a711` | `perf(raceAll)`: clear loser timer | actual leak fix — was leaking 13 background timers per `tm.get()` |
| `91f42f8` | `perf(system)`: memoize `getBrowser` | ~12 sequential UA regex matches → 1 |
| `790e8c0` | `perf(stableStringify)`: Set-based cycle detection | O(N²) → O(N) on tree traversal |
| `b83f0e1` | `fix(audio)`: remove `console.error` from production path | small cleanup |
| `7bff769` | `feat(functions)`: `_pipeline.*` + `_dispatch.<name>` instrumentation | adds keys to `elapsed` (only when `options.performance: true`) — the diagnostic surface that localized the remaining hot spots |
| `476a130` | `perf(webgl)`: module-scope cache of canvas + GL context + program + buffer | the biggest single win on Chromium — eliminates per-call shader compile + program link + buffer upload |
| `3c5f2cc` | `perf(commonPixels)`: short-circuit length-1, inline 3-way for length-3 | the biggest absolute-time win — was doing 80,000+ allocations to compute the most common byte of a single-element array |
| `5fc0bd6` | `test:` interactive perf harness (test.html) | session tooling |
| `9e44797` | `docs(perf)`: optimization report + running perf notes | included for posterity |
| `57ae07f` | `fix(webgl)`: context-loss recovery (`webglcontextlost` listener + `{ once: true }` + defense-in-depth in catch) | regression fix for tab-suspend cycles; verified via real-browser e2e test |
| `7917f98` | `chore`: bump 1.8.1 → 1.8.2 | release prep |

## Tests

- **164/164 Jest tests pass** (156 pre-existing + 8 new for the WebGL context-loss recovery).
- **New e2e Playwright test** `e2e/webgl-context-loss.spec.ts` uses `WEBGL_lose_context.loseContext()` to actually force context loss and asserts byte-identical hash recovery. Passes in 722 ms.
- Build clean (CJS / ESM / UMD / .d.ts).

## Hash-changing scenarios (acceptable — narrow, documented)

- **WebRTC**: users who previously hit the timeout path (`{ supported: true, ..., timeout: true }`) get a one-time hash transition to the deterministic `candidateType: 'host'` shape. These users were already getting non-deterministic fingerprints (timeout fires based on network conditions); now they get a deterministic one. Acceptable.
- **WebGL caching**: cache is OFF for Brave (which farbles `readPixels` per-context) — Brave's behavior is preserved exactly. Tor/Firefox-RFP typically disable WebGL or return constants — caching gives byte-identical output in those cases. Samsung Internet hash equivalence verified empirically.

## Notes for the reviewer

- New `_pipeline.*` and `_dispatch.<name>` keys are added to the `elapsed` map (only present when `options.performance: true`). They're `_`-prefixed to signal observability rather than feature surface. Strictly per semver this is an additive change; could justify either patch or minor — shipped as patch (1.8.2) since the dominant change is bug-fix-class perf improvements.
- WebGL caching uses `getBrowser().name !== 'Brave'` evaluated at module load time — module-level coupling to navigator state. Tests passing means the existing test harness sets up navigator before module import.
- `docs/perf-notes.md` and `docs/perf-optimization-report.md` document the full session including hash-stability discipline and follow-ups not pursued.

## Open follow-ups (do not block this PR — file as separate issues if desired)

From the code review:
- Comment in `webrtc/index.ts` tying the hardcoded `candidateType: 'host'` to the `iceServers: []` config (so a future change to add STUN remembers to undo the hardcode).
- JSDoc on `webgl/system` module-load coupling to navigator state.
- Direct test for `raceAllPerformance` timer-cleanup behavior using Jest fake timers.
- `getBrowser` cache reset documentation (the `__resetBrowserCache` foot-gun for tests).

## Deployment plan after merge

1. Merge this PR to main.
2. (Optional) `tm-secaudit` on main pre-publish.
3. (Optional) full cross-browser perf measurement (`tm-thumbmarkjs-perf` mode=full) for chromium + firefox + webkit.
4. `npm publish` from main.
5. `git tag v1.8.2` + `gh release create v1.8.2` with notes drawn from `docs/perf-optimization-report.md`.

These are explicit follow-ups, not part of this PR.