### PR TITLE
feat(components): graduate intl and mediadevices to production

### DIFF
--- a/src/components/intl/index.test.ts
+++ b/src/components/intl/index.test.ts
@@ -11,23 +11,14 @@ describe('intl component tests', () => {
     });
   });
 
-  test('returns valid structure with all expected keys', async () => {
+  test('returns valid structure with only hash key', async () => {
     const result = await getIntl();
 
     expect(result).not.toBeNull();
     expect(result).toHaveProperty('hash');
-    expect(result).toHaveProperty('details');
     expect(typeof result!.hash).toBe('string');
-    const details = result!.details as Record<string, unknown>;
-    const coreKeys = [
-      'dateFullFormat', 'dateMediumFormat', 'timeFormat',
-      'numberFormat', 'currencyFormat', 'percentFormat',
-      'nonLatinDate', 'nonLatinNumber',
-    ];
-    for (const key of coreKeys) {
-      expect(details).toHaveProperty(key);
-      expect(typeof details[key]).toBe('string');
-    }
+    expect(result!.hash).not.toBe('');
+    expect(result).not.toHaveProperty('details');
   });
 
   test('returns null when Intl is unavailable', async () => {
@@ -41,59 +32,13 @@ describe('intl component tests', () => {
     expect(result).toBeNull();
   });
 
-  test('omits listFormat when ListFormat is unavailable', async () => {
-    const mockIntl = Object.create(originalIntl);
-    Object.defineProperty(mockIntl, 'ListFormat', {
-      value: undefined,
-      configurable: true,
-    });
-    Object.defineProperty(globalThis, 'Intl', {
-      value: mockIntl,
-      configurable: true,
-      writable: true,
-    });
+  test('hash is stable across multiple calls', async () => {
+    const result1 = await getIntl();
+    const result2 = await getIntl();
 
-    const result = await getIntl();
-    const details = result!.details as Record<string, unknown>;
-
-    expect(result).not.toBeNull();
-    expect(details).toHaveProperty('dateFullFormat');
-    expect(details).not.toHaveProperty('listFormat');
-  });
-
-  test('omits displayNames when DisplayNames is unavailable', async () => {
-    const mockIntl = Object.create(originalIntl);
-    Object.defineProperty(mockIntl, 'DisplayNames', {
-      value: undefined,
-      configurable: true,
-    });
-    Object.defineProperty(globalThis, 'Intl', {
-      value: mockIntl,
-      configurable: true,
-      writable: true,
-    });
-
-    const result = await getIntl();
-    const details = result!.details as Record<string, unknown>;
-
-    expect(result).not.toBeNull();
-    expect(details).toHaveProperty('dateFullFormat');
-    expect(details).not.toHaveProperty('displayNames');
-  });
-
-  test('includes guarded probes when available', async () => {
-    const result = await getIntl();
-    const details = result!.details as Record<string, unknown>;
-
-    expect(result).not.toBeNull();
-    if (typeof (Intl as any).ListFormat === 'function') {
-      expect(details).toHaveProperty('listFormat');
-      expect(typeof details.listFormat).toBe('string');
-    }
-    if (typeof (Intl as any).DisplayNames === 'function') {
-      expect(details).toHaveProperty('displayNames');
-      expect(typeof details.displayNames).toBe('string');
-    }
+    expect(result1).not.toBeNull();
+    expect(result2).not.toBeNull();
+    expect(result1!.hash).toBe(result2!.hash);
   });
 
   test('returns null when Intl constructor throws', async () => {
@@ -112,13 +57,52 @@ describe('intl component tests', () => {
     expect(result).toBeNull();
   });
 
-  test('produces deterministic number format output', async () => {
-    const result = await getIntl();
-    const details = result!.details as Record<string, unknown>;
+  test('hash differs when ListFormat is unavailable vs available', async () => {
+    // Capture full hash first (with ListFormat and DisplayNames active)
+    const fullResult = await getIntl();
+    expect(fullResult).not.toBeNull();
+    const fullHash = fullResult!.hash;
 
+    // Stub out ListFormat and DisplayNames to exercise the no-optional-apis path
+    const mockIntlNoList = Object.create(originalIntl);
+    Object.defineProperty(mockIntlNoList, 'ListFormat', {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(mockIntlNoList, 'DisplayNames', {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'Intl', {
+      value: mockIntlNoList,
+      configurable: true,
+      writable: true,
+    });
+
+    const noListResult = await getIntl();
+    expect(noListResult).not.toBeNull();
+    const noListHash = noListResult!.hash;
+
+    // Restore before asserting so afterEach is not the only cleanup
+    Object.defineProperty(globalThis, 'Intl', {
+      value: originalIntl,
+      configurable: true,
+      writable: true,
+    });
+
+    // The two hashes must differ because the serialised input differs
+    expect(fullHash).not.toBe(noListHash);
+    // Both hashes must be non-empty strings
+    expect(fullHash).not.toBe('');
+    expect(noListHash).not.toBe('');
+  });
+
+  // Pinned regression guard: hash captured from a stable jsdom run.
+  // This value must only change intentionally when the Intl probe inputs
+  // (locale, options, date fixture, or field set) are deliberately modified.
+  test('hash matches pinned stable value', async () => {
+    const result = await getIntl();
     expect(result).not.toBeNull();
-    expect(details.numberFormat).toBe('123,456.789');
-    expect(details.currencyFormat).toBe('$123,456.79');
-    expect(details.percentFormat).toBe('46%');
+    expect(result!.hash).toBe('1cc951c228a133f7d6353d798f545ba3');
   });
 });

--- a/src/components/intl/index.ts
+++ b/src/components/intl/index.ts
@@ -32,7 +32,6 @@ export default async function getIntl(): Promise<componentInterface | null> {
     }
 
     return {
-      details,
       hash: hash(stableStringify(details)),
     };
   } catch {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -12,8 +12,10 @@ import getAudio from "./components/audio";
 import getCanvas from "./components/canvas";
 import getFonts from "./components/fonts";
 import getHardware from "./components/hardware";
+import getIntl from "./components/intl";
 import getLocales from "./components/locales";
 import getMath from "./components/math";
+import getMediaDevices from "./components/mediaDevices";
 import getPermissions from "./components/permissions";
 import getPlugins from "./components/plugins";
 import getScreen from "./components/screen";
@@ -21,8 +23,6 @@ import getSystem from "./components/system";
 import getWebGL from "./components/webgl";
 
 // Import experimental component functions
-import getIntl from "./components/intl";
-import getMediaDevices from "./components/mediaDevices";
 import getWebRTC from "./components/webrtc";
 import getMathML from "./components/mathml";
 import getSpeech from "./components/speech";
@@ -35,8 +35,10 @@ export const tm_component_promises = {
     'canvas': getCanvas,
     'fonts': getFonts,
     'hardware': getHardware,
+    'intl': getIntl,
     'locales': getLocales,
     'math': getMath,
+    'mediadevices': getMediaDevices,
     'permissions': getPermissions,
     'plugins': getPlugins,
     'screen': getScreen,
@@ -50,9 +52,7 @@ export const tm_component_promises = {
  * @description key->function map of experimental components. Only resolved during logging.
  */
 export const tm_experimental_component_promises = {
-    'intl': getIntl,
     'mathml': getMathML,
-    'mediadevices': getMediaDevices,
 };
 
 // the component interface is the form of the JSON object the function's promise must return


### PR DESCRIPTION
## What

Graduates two experimental components to production. They move from `tm_experimental_component_promises` into `tm_component_promises` in `src/factory.ts`. `mathml` remains experimental.

- **`mediadevices`** — graduated as-is → `{ audioinput, audiooutput, videoinput }`.
- **`intl`** — graduated but output trimmed to just `{ hash }`. The full `details` object was too noisy for production, so it's no longer returned. The `hash` **value is unchanged** — `details` is still built internally and the hash is still computed from it.

## ⚠️ Breaking change

`intl` and `mediadevices` are now part of the **main fingerprint hash**. Top-level fingerprint hashes will change for all users. This should be released as an appropriate (minor/major) version bump.

## Performance

These two components now run on every `fingerprint()` call (previously only during logging). Measured cost (chromium, 20 iter):
- `mediadevices`: ~2.7 ms (async `enumerateDevices()`)
- `intl`: ~0.07 ms (negligible)

Total mean fingerprint time ~99 ms.

## Verification

| Check | Result |
|---|---|
| `npm test` | 167 passed (incl. new intl hash-divergence + pinned-hash regression guard) |
| `npm run build` | ok |
| Code review | clean (2 test-quality issues found and fixed) |
| Perf | INITIAL baseline; +~2.8 ms hot-path cost, acceptable |
| Real-Chrome smoke test | PASS — `intl: { hash }` (no `details`), `mediadevices` present, 0 console errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)