### PR TITLE
feat(api): add simple_request option and stop sending api_key in body

### DIFF
--- a/src/functions/api.test.ts
+++ b/src/functions/api.test.ts
@@ -409,6 +409,125 @@ describe('getApiPromise timeout behavior', () => {
         });
     });
 
+    describe('request headers', () => {
+        beforeEach(() => {
+            jest.useRealTimers();
+        });
+
+        afterEach(() => {
+            jest.useFakeTimers();
+        });
+
+        const baseOpts = {
+            ...testOptions,
+            cache_api_call: false,
+            timeout: 5000,
+        };
+
+        test('DEFAULT mode: fetch is called with Content-Type application/json, x-api-key, and Authorization', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true, status: 200,
+                json: async () => ({ thumbmark: 'ok' }),
+            });
+
+            await getApiPromise({ ...baseOpts, api_key: 'my-key' }, testComponents);
+
+            const [, init] = mockFetch.mock.calls[0];
+            expect(init.headers['Content-Type']).toBe('application/json');
+            expect(init.headers['x-api-key']).toBe('my-key');
+            expect(init.headers['Authorization']).toBe('custom-authorized');
+        });
+
+        test('simple_request: true → fetch is called with Content-Type text/plain, no x-api-key, no Authorization', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true, status: 200,
+                json: async () => ({ thumbmark: 'ok' }),
+            });
+
+            await getApiPromise({ ...baseOpts, simple_request: true, api_key: undefined }, testComponents);
+
+            const [, init] = mockFetch.mock.calls[0];
+            expect(init.headers['Content-Type']).toBe('text/plain');
+            expect(init.headers['x-api-key']).toBeUndefined();
+            expect(init.headers['Authorization']).toBeUndefined();
+        });
+
+        test('simple_request: true → body is still JSON.stringify output', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true, status: 200,
+                json: async () => ({ thumbmark: 'ok' }),
+            });
+
+            await getApiPromise({ ...baseOpts, simple_request: true, api_key: undefined }, testComponents);
+
+            const [, init] = mockFetch.mock.calls[0];
+            expect(() => JSON.parse(init.body as string)).not.toThrow();
+        });
+
+        test('DEFAULT mode: request body options does NOT contain api_key, but x-api-key header still set', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true, status: 200,
+                json: async () => ({ thumbmark: 'ok' }),
+            });
+
+            await getApiPromise({ ...baseOpts, api_key: 'my-key' }, testComponents);
+
+            const [, init] = mockFetch.mock.calls[0];
+            // Header must still carry the key
+            expect(init.headers['x-api-key']).toBe('my-key');
+            // Body must NOT expose the key
+            const body = JSON.parse(init.body as string);
+            expect(body.options.api_key).toBeUndefined();
+        });
+
+        test('simple_request mode: request body options does NOT contain api_key', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true, status: 200,
+                json: async () => ({ thumbmark: 'ok' }),
+            });
+
+            await getApiPromise({ ...baseOpts, simple_request: true, api_key: 'proxy-injected-key' }, testComponents);
+
+            const [, init] = mockFetch.mock.calls[0];
+            // simple_request: no api_key header either
+            expect(init.headers['x-api-key']).toBeUndefined();
+            // Body must NOT expose the key
+            const body = JSON.parse(init.body as string);
+            expect(body.options.api_key).toBeUndefined();
+        });
+    });
+
+    describe('API call gate', () => {
+        beforeEach(() => {
+            jest.useRealTimers();
+        });
+
+        afterEach(() => {
+            jest.useFakeTimers();
+        });
+
+        const baseOpts = {
+            ...testOptions,
+            cache_api_call: false,
+            timeout: 5000,
+        };
+
+        test('fires when simple_request is true and no api_key is set', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true, status: 200,
+                json: async () => ({ thumbmark: 'simple-ok' }),
+            });
+
+            const result = await getApiPromise(
+                { ...baseOpts, simple_request: true, api_key: undefined },
+                testComponents
+            );
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(result?.thumbmark).toBe('simple-ok');
+        });
+    });
+
     test('returns full cached response (not just visitorId) when cache exists on timeout', async () => {
         const noCacheOptions = {
             ...testOptions,

--- a/src/functions/api.ts
+++ b/src/functions/api.ts
@@ -82,13 +82,16 @@ const RETRY_BACKOFF_MS = 200;
 async function callApi(
     endpoint: string, body: any, options: OptionsAfterDefaults, visitorId: string | null,
 ): Promise<apiResponse> {
-    const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
+    const headers: Record<string, string> = options.simple_request
+        ? { 'Content-Type': 'text/plain' }
+        : {
             'x-api-key': options.api_key!,
             'Authorization': 'custom-authorized',
             'Content-Type': 'application/json',
-        },
+        };
+    const response = await fetch(endpoint, {
+        method: 'POST',
+        headers,
         body: JSON.stringify(body),
     });
 
@@ -159,9 +162,11 @@ export const getApiPromise = (
         endpoint = `${apiEndpoint}/thumbmark`;
     }
     const visitorId = getVisitorId(options);
+    // Omit api_key from the body — in normal mode it goes in the x-api-key header; in simple_request mode it is proxy-injected.
+    const { api_key: _omitApiKey, ...optionsForBody } = options;
     const requestBody: any = {
         components,
-        options,
+        options: optionsForBody,
         clientHash: hash(stableStringify(components)),
         version: getVersion()
     };

--- a/src/functions/functions.test.ts
+++ b/src/functions/functions.test.ts
@@ -93,6 +93,47 @@ describe('resolveClientComponents runtime stability', () => {
     });
 });
 
+describe('getThumbmark API call gate', () => {
+    test('does not call fetch when neither api_key nor simple_request is set', async () => {
+        const fetchMock = jest.fn();
+        const originalFetch = global.fetch;
+        global.fetch = fetchMock;
+
+        await getThumbmark({
+            ...defaultOptions,
+            cache_api_call: false,
+        });
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        global.fetch = originalFetch;
+    });
+
+    test('calls fetch when simple_request is true and no api_key is set', async () => {
+        const fetchMock = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ thumbmark: 'proxy-ok', info: {} }),
+        });
+        const originalFetch = global.fetch;
+        global.fetch = fetchMock;
+
+        const result = await getThumbmark({
+            ...defaultOptions,
+            simple_request: true,
+            cache_api_call: false,
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [, init] = fetchMock.mock.calls[0];
+        expect(init.headers['Content-Type']).toBe('text/plain');
+        expect(init.headers['x-api-key']).toBeUndefined();
+        expect(init.headers['Authorization']).toBeUndefined();
+        expect(result.thumbmark).toBeDefined();
+
+        global.fetch = originalFetch;
+    });
+});
+
 describe('getThumbmark error reporting', () => {
     test('returns api_unauthorized error for 403 response', async () => {
         const originalFetch = global.fetch;

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -106,7 +106,7 @@ export async function getThumbmark(
       allErrors.push(...expErrors);
     }
 
-    const apiPromise = _options.api_key ? getApiPromise(_options, clientComponentsResult) : null;
+    const apiPromise = (_options.api_key || _options.simple_request) ? getApiPromise(_options, clientComponentsResult) : null;
     let apiResult = null;
 
     if (apiPromise) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -19,6 +19,12 @@ export interface OptionsAfterDefaults {
     api_key?: string,
     api_endpoint?: string,
     /**
+     * When true, the API request is sent as a CORS "simple request" (Content-Type: text/plain,
+     * no custom headers). Use this when routing through a proxy that attaches the real API key.
+     * Requires neither api_key nor Authorization header from the client side.
+     */
+    simple_request?: boolean,
+    /**
      * @deprecated This will be removed in Thumbmarkjs 2.0, use cache_lifetime_in_ms instead
      */
     cache_api_call?: boolean,
@@ -58,6 +64,7 @@ export const defaultOptions: OptionsAfterDefaults = {
     cache_lifetime_in_ms: DEFAULT_CACHE_LIFETIME,
     performance: false,
     experimental: false,
+    simple_request: false,
     property_name_factory: (name: string) => {
         return `${DEFAULT_STORAGE_PREFIX}_${name}`;
     },


### PR DESCRIPTION
## What

Adds an opt-in `simple_request` option so the API call can be sent as a CORS **simple request** (no preflight), for clients routing through a proxy that attaches the real API key. Also stops embedding `api_key` in the request body.

### `simple_request` (default `false`)

When `true`, `callApi` sends only `Content-Type: text/plain` and **drops both** the `x-api-key` and `Authorization` headers. Any custom header forces a CORS preflight, so removing them (not just changing the content type) is what makes it a true simple request. The body is still the JSON string — the proxy parses it and injects the real key.

```js
new Thumbmark({ api_endpoint: 'https://your-proxy/path', simple_request: true }).get();
```

The call-trigger gate now fires on `api_key || simple_request`, so the old dummy-key workaround (`api_key: 'ZZ'`) is **no longer needed**.

### `api_key` removed from the request body

Previously the full `options` object — including `api_key` — was serialized into the POST body. The key now belongs only where it's needed: the `x-api-key` header in normal mode, or proxy-injected in `simple_request` mode. `clientHash` is unaffected (it hashes `components`, not `options`).

> Assumes the server reads the key from the header, not the body.

## Backwards compatibility

Fully compatible. Clients that don't set `simple_request` get identical request behavior, **except** `api_key` no longer appears in the body.

## Verification

| Check | Result |
|---|---|
| `npm test` | 180 passed (new tests: headers in both modes, gate fires without key, `api_key` absent from body in both modes) |
| `npm run build` | ok |
| Code review | clean (1 minor comment fix) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)