### PR TITLE
feat(components): graduate mathml to production

### DIFF
--- a/src/components/mathml/index.test.ts
+++ b/src/components/mathml/index.test.ts
@@ -1,0 +1,156 @@
+import getMathML from './index';
+
+// Mock the ephemeralIFrame utility so we control the iframe document passed to the callback
+jest.mock('../../utils/ephemeralIFrame', () => ({
+  ephemeralIFrame: jest.fn(),
+}));
+
+import { ephemeralIFrame } from '../../utils/ephemeralIFrame';
+const mockEphemeralIFrame = ephemeralIFrame as jest.MockedFunction<typeof ephemeralIFrame>;
+
+/** Build a minimal fake iframe Document for use in tests. */
+function makeFakeIframe(rectWidth: number, rectHeight: number): Document {
+  const fakeRect = {
+    width: rectWidth,
+    height: rectHeight,
+    top: 0, left: 0, bottom: rectHeight, right: rectWidth, x: 0, y: 0,
+    toJSON: () => {},
+  };
+
+  const fakeComputedStyle = {
+    fontFamily: 'serif',
+    fontSize: '16px',
+    fontWeight: '400',
+    fontStyle: 'normal',
+    lineHeight: '20px',
+    fontVariant: 'normal',
+    fontStretch: 'normal',
+    fontSizeAdjust: 'none',
+    textRendering: 'auto',
+    fontFeatureSettings: 'normal',
+    fontVariantNumeric: 'normal',
+    fontKerning: 'auto',
+  };
+
+  // Track appended/removed children to avoid missing-child errors
+  const children: Element[] = [];
+
+  const fakeBody = {
+    appendChild: (el: Element) => { children.push(el); return el; },
+    removeChild: (el: Element) => {
+      const idx = children.indexOf(el);
+      if (idx !== -1) children.splice(idx, 1);
+      return el;
+    },
+  };
+
+  const fakeElement = {
+    innerHTML: '',
+    style: { position: '', visibility: '', top: '', whiteSpace: '' },
+    getBoundingClientRect: jest.fn().mockReturnValue(fakeRect),
+  };
+
+  const fakeWindow = {
+    getComputedStyle: jest.fn().mockReturnValue(fakeComputedStyle),
+  };
+
+  return {
+    body: fakeBody,
+    createElement: jest.fn().mockReturnValue(fakeElement),
+    defaultView: fakeWindow,
+  } as unknown as Document;
+}
+
+describe('mathml component tests', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns { supported: false } when MathML is not supported', async () => {
+    // 0x0 rect means isMathMLSupported returns false
+    const fakeIframe = makeFakeIframe(0, 0);
+    mockEphemeralIFrame.mockImplementation(async (cb) => { await cb({ iframe: fakeIframe }); });
+
+    const result = await getMathML();
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('supported', false);
+    expect(result).toHaveProperty('error', 'MathML not supported');
+    expect(result).not.toHaveProperty('hash');
+    expect(result).not.toHaveProperty('details');
+  });
+
+  test('returns { hash } without details on success path when MathML is supported', async () => {
+    // Non-zero rect — isMathMLSupported returns true, success path runs
+    const fakeIframe = makeFakeIframe(100, 20);
+    mockEphemeralIFrame.mockImplementation(async (cb) => { await cb({ iframe: fakeIframe }); });
+
+    const result = await getMathML();
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('hash');
+    expect(typeof result!.hash).toBe('string');
+    expect(result!.hash).not.toBe('');
+    // details must NOT appear in the output
+    expect(result).not.toHaveProperty('details');
+    // supported key is absent from success shape
+    expect(result).not.toHaveProperty('supported');
+  });
+
+  test('hash is stable across two calls with identical mocked measurements', async () => {
+    const fakeIframe = makeFakeIframe(50, 15);
+    mockEphemeralIFrame.mockImplementation(async (cb) => { await cb({ iframe: fakeIframe }); });
+
+    const result1 = await getMathML();
+    const result2 = await getMathML();
+
+    expect(result1).not.toBeNull();
+    expect(result2).not.toBeNull();
+    expect(result1!.hash).toBe(result2!.hash);
+  });
+
+  test('resolves with { hash } (empty dimensions) when all individual measurements fail', async () => {
+    // Support check passes (first element has non-zero rect) but all subsequent
+    // createElement calls (used by measureMathMLStructure) throw — those are
+    // caught internally by measureMathMLStructure and return { error }, so the
+    // dimensions array is empty. The component must still resolve gracefully.
+    let callCount = 0;
+    const fakeComputedStyle = {
+      fontFamily: 'serif', fontSize: '16px', fontWeight: '400', fontStyle: 'normal',
+      lineHeight: '20px', fontVariant: 'normal', fontStretch: 'normal',
+      fontSizeAdjust: 'none', textRendering: 'auto', fontFeatureSettings: 'normal',
+      fontVariantNumeric: 'normal', fontKerning: 'auto',
+    };
+    const fakeBody = { appendChild: jest.fn(), removeChild: jest.fn() };
+    const fakeWindow = { getComputedStyle: jest.fn().mockReturnValue(fakeComputedStyle) };
+    const fakeIframe = {
+      body: fakeBody,
+      defaultView: fakeWindow,
+      createElement: jest.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // Support check element: non-zero rect so isMathMLSupported returns true
+          return {
+            innerHTML: '',
+            style: { position: '', visibility: '', top: '', whiteSpace: '' },
+            getBoundingClientRect: jest.fn().mockReturnValue({ width: 100, height: 20 }),
+          };
+        }
+        // All measurement elements: throw (caught by measureMathMLStructure internally)
+        throw new Error('createElement failed');
+      }),
+    } as unknown as Document;
+
+    mockEphemeralIFrame.mockImplementation(async (cb) => { await cb({ iframe: fakeIframe }); });
+
+    const result = await getMathML();
+
+    // Even with all measurements failing, we still get a hash (of the empty structure)
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('hash');
+    expect(typeof result!.hash).toBe('string');
+    expect(result!.hash).not.toBe('');
+    expect(result).not.toHaveProperty('details');
+    expect(result).not.toHaveProperty('supported');
+  });
+});

--- a/src/components/mathml/index.ts
+++ b/src/components/mathml/index.ts
@@ -20,25 +20,26 @@ export default async function getMathML(): Promise<componentInterface | null> {
           }
 
           const structures = [
-            createMathML('integral', '<msubsup><mo>\u222B</mo><mi>a</mi><mi>b</mi></msubsup><mfrac><mrow><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow><mrow><mi>g</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mfrac><mi>dx</mi>'),
-            createMathML('fraction', '<mfrac><mrow><mi>\u03C0</mi><mo>\u00D7</mo><msup><mi>r</mi><mn>2</mn></msup></mrow><mrow><mn>2</mn><mi>\u03C3</mi></mrow></mfrac>'),
-            createMathML('matrix', '<mo>[</mo><mtable><mtr><mtd><mi>\u03B1</mi></mtd><mtd><mi>\u03B2</mi></mtd></mtr><mtr><mtd><mi>\u03B3</mi></mtd><mtd><mi>\u03B4</mi></mtd></mtr></mtable><mo>]</mo>'),
+            createMathML('<msubsup><mo>\u222B</mo><mi>a</mi><mi>b</mi></msubsup><mfrac><mrow><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow><mrow><mi>g</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mfrac><mi>dx</mi>'),
+            createMathML('<mfrac><mrow><mi>\u03C0</mi><mo>\u00D7</mo><msup><mi>r</mi><mn>2</mn></msup></mrow><mrow><mn>2</mn><mi>\u03C3</mi></mrow></mfrac>'),
+            createMathML('<mo>[</mo><mtable><mtr><mtd><mi>\u03B1</mi></mtd><mtd><mi>\u03B2</mi></mtd></mtr><mtr><mtd><mi>\u03B3</mi></mtd><mtd><mi>\u03B4</mi></mtd></mtr></mtable><mo>]</mo>'),
             createComplexNestedStructure(),
             ...createSymbolStructures()
           ];
 
-          const dimensionsArray: any[] = [];
+          const dimensionsArray: Array<{ width: number; height: number }> = [];
           let fontStyleHash: string = '';
 
           structures.forEach((struct, i) => {
             const measurement = measureMathMLStructure(struct, iframe);
+            if (!('dimensions' in measurement)) return;
             // Extract dimensions for this structure
             dimensionsArray.push({
               width: measurement.dimensions.width,
               height: measurement.dimensions.height
             });
             // Capture font style hash from the first structure (it's the same for all)
-            if (i === 0 && measurement.fontInfo) {
+            if (i === 0) {
               fontStyleHash = hash(stableStringify(measurement.fontInfo));
             }
           });
@@ -49,8 +50,6 @@ export default async function getMathML(): Promise<componentInterface | null> {
           };
 
           resolve({
-            //supported: true,
-            details,
             hash: hash(stableStringify(details))
           });
 
@@ -87,7 +86,7 @@ function isMathMLSupported(iframe: Document): boolean {
   }
 }
 
-function createMathML(name: string, content: string): string {
+function createMathML(content: string): string {
   return `<math><mrow>${content}</mrow></math>`;
 }
 
@@ -104,7 +103,7 @@ function createComplexNestedStructure(): string {
     }
   });
 
-  return createMathML('complex_nested',
+  return createMathML(
     `<munderover><mmultiscripts>${nestedContent}</mmultiscripts></munderover>`
   );
 }
@@ -119,7 +118,7 @@ function createSymbolStructures(): string[] {
     const greekSet = GREEK_SYMBOLS.slice(startIdx, startIdx + 2);
 
     if (greekSet.length === 2) {
-      structures.push(createMathML('combined',
+      structures.push(createMathML(
         `<mmultiscripts><mi>${bbSymbol}</mi><none/><mi>${greekSet[1]}</mi><mprescripts></mprescripts><mi>${greekSet[0]}</mi><none/></mmultiscripts>`
       ));
     }
@@ -128,7 +127,11 @@ function createSymbolStructures(): string[] {
   return structures;
 }
 
-function measureMathMLStructure(mathml: string, iframe: Document): any {
+type MathMLMeasurement =
+  | { dimensions: { width: number; height: number }; fontInfo: Record<string, string> }
+  | { error: string };
+
+function measureMathMLStructure(mathml: string, iframe: Document): MathMLMeasurement {
   try {
     const mathElement = iframe.createElement('math');
     mathElement.innerHTML = mathml.replace(/<\/?math>/g, '');

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -15,6 +15,7 @@ import getHardware from "./components/hardware";
 import getIntl from "./components/intl";
 import getLocales from "./components/locales";
 import getMath from "./components/math";
+import getMathML from "./components/mathml";
 import getMediaDevices from "./components/mediaDevices";
 import getPermissions from "./components/permissions";
 import getPlugins from "./components/plugins";
@@ -24,7 +25,6 @@ import getWebGL from "./components/webgl";
 
 // Import experimental component functions
 import getWebRTC from "./components/webrtc";
-import getMathML from "./components/mathml";
 import getSpeech from "./components/speech";
 
 /**
@@ -38,6 +38,7 @@ export const tm_component_promises = {
     'intl': getIntl,
     'locales': getLocales,
     'math': getMath,
+    'mathml': getMathML,
     'mediadevices': getMediaDevices,
     'permissions': getPermissions,
     'plugins': getPlugins,
@@ -51,9 +52,7 @@ export const tm_component_promises = {
 /**
  * @description key->function map of experimental components. Only resolved during logging.
  */
-export const tm_experimental_component_promises = {
-    'mathml': getMathML,
-};
+export const tm_experimental_component_promises: Record<string, never> = {};
 
 // the component interface is the form of the JSON object the function's promise must return
 export interface componentInterface {


### PR DESCRIPTION
## What

Graduates the experimental `mathml` component to production — the last component in the experimental map, which is now empty.

- Moved `mathml` from `tm_experimental_component_promises` into `tm_component_promises` in `src/factory.ts`.
- **Trimmed output to `{ hash }`** — the verbose `details` (fontStyleHash + ~17 width/height dimension pairs) is no longer emitted, consistent with how `intl` was graduated. The `hash` **value is unchanged** (still computed from the full `details` internally).
- The unsupported/error path (`{ supported: false, error }`) is untouched.
- Minor code-review cleanup in the same file: removed an unused `createMathML` parameter, narrowed `any` types, and added a measurement-failure narrowing guard (also prevents a `TypeError` when a measurement fails).

## ⚠️ Breaking change

`mathml` now contributes to the **main fingerprint hash**, so top-level fingerprint hashes will change for all users. Should be released as an appropriate (minor/major) version bump.

## Verification

| Check | Result |
|---|---|
| `npm test` | 176 passed (mathml tests rewritten to mock the iframe and cover both the unsupported and success `{ hash }` paths) |
| `npm run build` | ok |
| Code review | clean (minor type/cleanup fixes applied) |
| Perf | mathml cost is a cold-start (iframe allocation on first call); amortizes to negligible per-call. Runs once per fingerprint. |
| Real-Chrome smoke test | PASS — `mathml: { hash: "fbb0738e…" }` present (no `details`, not `supported:false`), 0 console errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)