### PR TITLE
fix: name the CommonJS build .cjs so Node parses it as CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "version": "1.10.0",
   "description": "",
   "type": "module",
-  "main": "./dist/thumbmark.cjs.js",
+  "main": "./dist/thumbmark.cjs",
   "module": "./dist/thumbmark.esm.js",
   "types": "./dist/thumbmark.esm.d.ts",
   "exports": {
     ".": {
       "types": "./dist/thumbmark.esm.d.ts",
       "import": "./dist/thumbmark.esm.js",
-      "require": "./dist/thumbmark.cjs.js"
+      "require": "./dist/thumbmark.cjs"
     }
   },
   "public": true,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -17,7 +17,9 @@ const config = [
     input: 'src/index.ts', // replace with your entry file
     output: [
       {
-        file: 'dist/thumbmark.cjs.js',
+        // .cjs, not .cjs.js: package.json declares "type": "module", which makes Node
+        // parse every .js file in this package as ESM regardless of the rest of the name.
+        file: 'dist/thumbmark.cjs',
         format: 'cjs',
         sourcemap: true,
       },

--- a/src/packaging.test.ts
+++ b/src/packaging.test.ts
@@ -1,0 +1,76 @@
+import { execFileSync } from 'child_process';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+/**
+ * Guards the dual CommonJS/ES module packaging of this package.
+ *
+ * package.json declares "type": "module". Node then parses EVERY .js file in this package
+ * as ESM, no matter what the rest of the filename says — so a CommonJS build named
+ * `thumbmark.cjs.js` is loaded as ESM and dies on its own `exports.x = ...` with
+ * "ReferenceError: exports is not defined in ES module scope".
+ * The CommonJS artifact must therefore end in `.cjs`.
+ *
+ * See https://nodejs.org/api/packages.html#determining-module-system
+ */
+const pkgRoot = resolve(__dirname, '..');
+const pkg = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8'));
+
+describe('package.json module resolution', () => {
+  const isTypeModule = pkg.type === 'module';
+
+  it('declares "type": "module" (assumption the rules below rest on)', () => {
+    expect(isTypeModule).toBe(true);
+  });
+
+  it('points "main" at a CommonJS file that Node will actually parse as CommonJS', () => {
+    expect(pkg.main).toMatch(/\.cjs$/);
+  });
+
+  it('points the "require" export condition at a .cjs file', () => {
+    expect(pkg.exports['.'].require).toMatch(/\.cjs$/);
+  });
+
+  it('never exposes a .js file through the "require" condition while "type" is "module"', () => {
+    // The regression this suite exists to prevent: a .js file reached via `require`
+    // in a type:module package is parsed as ESM and cannot work as CommonJS.
+    const requirePaths = Object.values(pkg.exports as Record<string, { require?: string }>)
+      .map((cond) => cond.require)
+      .filter((p): p is string => typeof p === 'string');
+
+    expect(requirePaths.length).toBeGreaterThan(0);
+    for (const p of requirePaths) {
+      expect(p.endsWith('.js')).toBe(false);
+    }
+  });
+});
+
+/**
+ * The static checks above cannot prove the built file actually loads, and this suite
+ * deliberately does NOT use jest's own `require`: jest wraps every module in a CommonJS
+ * wrapper that injects `exports`/`module`/`require` and ignores "type": "module"
+ * entirely, so the broken build loads fine under jest and the bug stays invisible.
+ * Only a real `node` process reproduces Node's resolution. Skipped when dist/ is absent.
+ */
+const cjsPath = join(pkgRoot, pkg.main);
+const built = existsSync(cjsPath);
+const describeIfBuilt = built ? describe : describe.skip;
+
+describeIfBuilt('built CommonJS artifact (requires `npm run build`)', () => {
+  it('loads under a real node process and exposes its named exports', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'tmjs-cjs-'));
+    const probe = join(dir, 'probe.cjs');
+    // A real file, never `node -e`: `node -e` leaks a global `exports` binding that
+    // silently absorbs the writes and turns this test green against a broken build.
+    writeFileSync(
+      probe,
+      `const tm = require(${JSON.stringify(cjsPath)});\n` +
+        `if (typeof tm.getThumbmark !== 'function') { throw new Error('getThumbmark missing'); }\n` +
+        `process.stdout.write('ok');\n`
+    );
+
+    const out = execFileSync(process.execPath, [probe], { encoding: 'utf8' });
+    expect(out).toBe('ok');
+  });
+});


### PR DESCRIPTION
## The problem

`package.json` declares `"type": "module"`, so Node parses **every** `.js` file in this package as ESM. That includes `dist/thumbmark.cjs.js` — the `.cjs` in the middle is decorative, the final extension is `.js`, so `type` governs.

The `require` condition therefore hands consumers a CommonJS body that Node evaluates as ESM. It dies on its own first `exports.x = ...`:

```
ReferenceError: exports is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension
and '.../node_modules/@thumbmarkjs/thumbmarkjs/package.json' contains "type": "module".
To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
```

Node's own error message prescribes the fix.

### Reproducing

```bash
npm i @thumbmarkjs/thumbmarkjs@1.10.0
printf "const t = require('@thumbmarkjs/thumbmarkjs'); console.log(Object.keys(t));" > probe.cjs
node probe.cjs   # ReferenceError: exports is not defined in ES module scope
```

> Use a real file, not `node -e`. `node -e` leaves a global `exports` in scope (`typeof exports === 'object'`), which absorbs the writes and makes a broken build look fine.

### Scope

Any consumer whose resolution takes the `require` condition: `require()` from CommonJS, SSR / `target: 'node'` bundles, `esbuild --platform=node --format=cjs`. Consumers on the `import` condition are unaffected, which is why this has stayed quiet.

Bundlers make it worse by hiding it — webpack 5 compiles the broken file with **zero errors and zero warnings** and emits a bundle that throws at runtime. In some scopes there is no error at all: the writes land on a stray `exports` object and the import silently resolves to an empty namespace, surfacing later as `X is not a constructor`.

### When it started

`"type": "module"` was added in 715016a (`0.20.5` → `0.20.6`) without renaming the CJS output. Present in every release since, including 1.10.0.

## The fix

Rename the rollup CJS output to `dist/thumbmark.cjs` and point `main` + the `require` condition at it. Three lines.

`.esm.js` and `.umd.js` are untouched, and this is **not a breaking change** — the exports map has no wildcard, so deep imports of `dist/thumbmark.cjs.js` already throw `ERR_PACKAGE_PATH_NOT_EXPORTED` and cannot exist in the wild.

## Tests

Per CONTRIBUTING, this includes tests — `src/packaging.test.ts`:

- Static assertions that the `require` condition never points at a `.js` file while `type` is `module`.
- A runtime check that loads the built artifact and asserts its named exports.

The runtime check **spawns a real `node` process on purpose**. Jest wraps every module in a CommonJS wrapper that injects `exports`/`module`/`require` and ignores `"type": "module"` entirely — so the broken build passes under Jest and the bug is invisible to the existing suite. That is worth knowing independently of this PR: a green Jest run is not evidence that the published package resolves.

Verified both ways:

| | packaging test | full suite |
|---|---|---|
| current `main` (broken) | **4 of 5 fail** (incl. the real-node load) | — |
| with this fix | 5 of 5 pass | **172 passed, 16 suites** |

## Notes

- Happy to open an issue first if you'd prefer that per CONTRIBUTING — it seemed small enough to just show the patch.
- Unrelated, noticed while building: `npm ci && npm run build` fails on a clean checkout with `Could not find module 'tslib', which is required by this plugin`. `tslib` is a peer requirement of `@rollup/plugin-typescript` but isn't declared. I installed it locally to verify this PR and deliberately left it out to keep the diff focused — worth a separate fix.
