### PR TITLE
chore(deps): patch five high-severity advisories in dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2130,9 +2130,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3022,9 +3022,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -3216,9 +3216,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4568,9 +4568,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Clears the 5 open high-severity Dependabot alerts. `npm audit` goes from 3 findings to **0 vulnerabilities**.

| package | from | to | advisories |
|---|---|---|---|
| `js-yaml` | 3.15.0 | 3.15.1 | GHSA-5p4m-2wfm-xmqj |
| `fast-uri` | 3.1.2 | 3.1.5 | CVE-2026-13676, CVE-2026-16221, CVE-2026-18446 |
| `brace-expansion` | 1.1.14 / 2.1.0 | 1.1.18 / 2.1.4 | CVE-2026-13149 |

## Scope

`package-lock.json` only. `npm audit fix` without `--force`, so no direct dependency in `package.json` moves and no major versions change — typescript stays 5.3.3, jest 29.7.0, rollup 4.60.4.

## Impact

All five are **transitive and development-scoped**, so none reaches the published bundle. Verified rather than assumed: rebuilt on either side of the lockfile change and compared output — `dist/thumbmark.umd.js` and `dist/thumbmark.esm.js` are byte-identical before and after.

That makes these CI/supply-chain hygiene rather than a risk to library consumers. Worth merging promptly, but no user-facing urgency.

## Verification

- `npm audit` → 0 vulnerabilities
- `npx tsc --noEmit` → clean
- `npm test` → 171 passed, 1 skipped (the skip is `packaging.test.ts`, which is conditional on `dist/` being built — pre-existing)
- `npm run build` → clean, output byte-identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)