### PR TITLE
docs(readme): describe sampled logging and the remote payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,28 @@ const tm = new ThumbmarkJS.Thumbmark({
 | `include` | string[] | — | Only include these components. `exclude` still applies. |
 | `permissions_to_check` | string[] | — | Limit which browser permissions are checked. Permissions are the slowest component to resolve. |
 | `timeout` | integer | 5000 | Component timeout in milliseconds. |
-| `logging` | boolean | true | At most 0.01% of runs collect anonymous logs to improve the library. Has no effect on users. |
+| `logging` | boolean | true | At most 0.01% of runs send an anonymous sample to improve the library. See [Sampled logging](#sampled-logging). |
 | `performance` | boolean | false | When true, includes per-component resolution time in milliseconds. |
 | `stabilize` | string[] | `['private', 'iframe']` | Preset exclusion list for stability across private browsing and iframes. |
 | `metadata` | varies | — | Passed to webhooks. Does not affect the fingerprint. |
 
 See the [configuration reference →](https://docs.thumbmarkjs.com/docs/configuration/options)
+
+### Sampled logging
+
+By default, at most 0.01% of runs — and never more than once per browser session — send an anonymous sample to `api.thumbmarkjs.com/log`. This is how the library gets improved: it shows which components turn out to be unstable across real browsers.
+
+When a run is sampled, the library also fetches a small script from `experimental.thumbmarkjs.com` and evaluates it. That script computes fraud-prevention signals that are still under evaluation — they are included in the sample but are **not** part of the fingerprint hash and are never returned to the caller. Keeping them out of the bundle means they can be iterated without a release.
+
+The script is published in readable, non-minified form alongside the minified build the library actually loads, so you can read exactly what runs: [experimental.js](https://experimental.thumbmarkjs.com/experimental.js)
+
+Nothing is fetched or evaluated on the other 99.99% of runs. To disable both the sample and the fetch:
+
+```javascript
+const tm = new ThumbmarkJS.Thumbmark({ logging: false })
+```
+
+If your Content Security Policy omits `'unsafe-eval'`, or does not allow `experimental.thumbmarkjs.com`, the fetch or evaluation fails silently and fingerprinting is unaffected.
 
 ### Integrations
 


### PR DESCRIPTION
Follow-up to #148. The README's `logging` row said:

> At most 0.01% of runs collect anonymous logs to improve the library. **Has no effect on users.**

That was fair when logging meant posting some JSON. Since 1.11.0 a sampled run also fetches a script from `experimental.thumbmarkjs.com` and evaluates it in the user's page. That's a material change to what `logging: true` means, and it's discoverable by anyone who opens the bundle and finds `eval` — better they read it from us first.

`experimental` itself was never mentioned in the README, so nothing needed removing; this is entirely about `logging`.

## Changes

- **Table row** — replaced "Has no effect on users" with a pointer to the new section.
- **New `### Sampled logging` section** after the config table.

## What the section says, and why

- **"evaluates" stated plainly.** Softening it to "loads additional signals" would read as concealment the moment someone opens the source.
- **Links the readable artifact** — [experimental.js](https://experimental.thumbmarkjs.com/experimental.js) is published non-minified alongside the minified build the library loads, so the claim is checkable in one click. That's the strongest thing available here and worth a sentence.
- **States the negative bounds** a suspicious reader actually wants: not in the fingerprint hash, never returned to the caller, nothing fetched on the other 99.99% of runs, `logging: false` disables both the sample and the fetch.
- **Notes CSP behaviour.** An integrator whose policy omits `'unsafe-eval'` or blocks the origin would otherwise have no way to know the payload silently no-ops for them.

## Verification

Every factual claim checked against `main` rather than drafted from memory:

| Claim | Source |
|---|---|
| at most 0.01%, once per session | `functions/index.ts:83` — `Math.random() < 0.0001` + `_tmjs_l` guard |
| posts to `api.thumbmarkjs.com/log` | `log.ts:21` + `options.ts:61` |
| fetches from `experimental.thumbmarkjs.com` | `experimental.ts:13` |
| not in hash, never returned to caller | zero occurrences of `experimental` in `functions/index.ts` |
| nothing fetched on unsampled runs | `getExperimentalPayload` is called only from `log.ts:28` |
| readable artifact reachable | `HTTP 200, 30,382 B` |

Docs-only — no source, build, or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)