### PR TITLE
feat(api): send the page path with the API request

### DIFF
--- a/src/functions/api.test.ts
+++ b/src/functions/api.test.ts
@@ -409,6 +409,48 @@ describe('getApiPromise timeout behavior', () => {
         });
     });
 
+    describe('request body: path', () => {
+        beforeEach(() => { jest.useRealTimers(); });
+        afterEach(() => { jest.useFakeTimers(); });
+
+        const baseOpts = { ...testOptions, cache_api_call: false, timeout: 5000, api_key: 'k' };
+
+        function bodyOf() {
+            const [, init] = mockFetch.mock.calls[0];
+            return JSON.parse(init.body);
+        }
+
+        test('sends the current pathname as `path`', async () => {
+            window.history.pushState({}, '', '/checkout/step-2');
+            mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ thumbmark: 'ok' }) });
+
+            await getApiPromise(baseOpts, testComponents);
+
+            expect(bodyOf().path).toBe('/checkout/step-2');
+        });
+
+        test('path is not part of clientHash, so the fingerprint does not follow the page', async () => {
+            // The whole point of keeping `path` a sibling of `components`: two
+            // requests from different pages on the same browser must still hash
+            // identically, or every navigation looks like a new device.
+            window.history.pushState({}, '', '/page-a');
+            mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ thumbmark: 'ok' }) });
+            await getApiPromise(baseOpts, testComponents);
+            const first = bodyOf();
+
+            mockFetch.mockClear();
+            window.history.pushState({}, '', '/page-b');
+            mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ thumbmark: 'ok' }) });
+            await getApiPromise(baseOpts, testComponents);
+            const second = bodyOf();
+
+            expect(first.path).toBe('/page-a');
+            expect(second.path).toBe('/page-b');
+            expect(second.clientHash).toBe(first.clientHash);
+            expect(second.components).toEqual(first.components);
+        });
+    });
+
     describe('request headers', () => {
         beforeEach(() => {
             jest.useRealTimers();

--- a/src/functions/api.ts
+++ b/src/functions/api.ts
@@ -168,7 +168,11 @@ export const getApiPromise = (
         components,
         options: optionsForBody,
         clientHash: hash(stableStringify(components)),
-        version: getVersion()
+        version: getVersion(),
+        // Sits alongside components rather than inside it, so it reaches the API
+        // and webhooks without entering clientHash — the fingerprint must not
+        // change with the page it was taken on.
+        path: window?.location?.pathname,
     };
     if (visitorId) {
         requestBody.visitorId = visitorId;


### PR DESCRIPTION
Adds `path` to the API request body, carrying `window.location.pathname`, so the API can see which page a fingerprint was taken on. Mirrors the field the sampled log has always sent.

```diff
 const requestBody: any = {
     components,
     options: optionsForBody,
     clientHash: hash(stableStringify(components)),
     version: getVersion(),
+    path: window?.location?.pathname,
 };
```

## Two deliberate properties

**It sits beside `components`, not inside it.** `clientHash` is computed from `components` alone, so `path` cannot enter the fingerprint. If it could, every navigation would look like a new device. There's a test asserting two requests from different paths produce an identical `clientHash`.

**Pathname only — no query string, no fragment.** `?token=…`, `?email=…` and similar are far more likely to carry credentials or personal data than the path itself, and nothing here needs them. This matches what the log already sends.

## Verification

- 210 tests pass (2 new), build clean.
- Confirmed the field reaches the built bundle.

## One thing worth knowing before relying on it

`path` is only sent when a request actually goes out, and the API response is memoised. `apiPromiseResult` is set on every successful call (`api.ts:102`) and returned early while `cache_api_call` is true — which is the **default**.

In practice:

- **Multi-page sites** — a full page load clears the memo, so each navigation sends its own `path`. Works as expected.
- **SPAs** — no full page load, so the memo survives route changes. A second `getThumbmark()` after a client-side navigation returns the cached response without a request, and that later `path` is never sent. Customers would see only the entry page.
- **`cache_lifetime_in_ms > 0`** — same effect, extended across page loads via localStorage for the configured window.

Not a defect and not changed here — it's pre-existing caching behaviour. But it shapes what the data means, so it's worth deciding whether SPA route coverage matters before telling customers what to expect from this field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)