### PR TITLE
fix(npm): add description, repository, homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thumbmarkjs/thumbmarkjs",
   "version": "1.11.0",
-  "description": "",
+  "description": "Free, open-source browser fingerprinting library. Identify returning visitors, detect fraud and bots — client-side, cookieless, no backend required.",
   "type": "module",
   "main": "./dist/thumbmark.cjs",
   "module": "./dist/thumbmark.esm.js",
@@ -77,6 +77,14 @@
   ],
   "author": "Ilkka Peltola",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thumbmarkjs/thumbmarkjs.git"
+  },
+  "homepage": "https://www.thumbmarkjs.com",
+  "bugs": {
+    "url": "https://github.com/thumbmarkjs/thumbmarkjs/issues"
+  },
   "unpkg": "dist/thumbmark.umd.js",
   "overrides": {
     "js-yaml": "^3.15.0"


### PR DESCRIPTION
## Problem

`description` in `package.json` is set to an empty string. The npm registry
treats an empty description the same as a missing one and falls back to the
README, so the published packument for v1.11.0 carries ~255 characters of
truncated HTML — the README's opening `<picture>` block, cut off mid-attribute,
with raw `\r` line endings — as the package description.

That string is what npm renders as the one-line pitch in search results, and
it is the `<meta name="description">` on the package page, so it is also what
search engines and LLM crawlers index as the summary of this package.

This is not a recent regression: the field has been empty throughout. The
*content* changed between 1.9.0 and 1.10.0 only because the README's opening
lines changed (badge block → `<picture>` block). It will keep silently
re-tracking whatever the README happens to open with until the field is set.

Also missing from the published metadata: `repository`, `homepage`, `bugs`.
Without them the npm page shows no Repository link and no GitHub sidebar,
`npm repo` and `npm bugs` both fail, and there is no path from the npm page
back to thumbmarkjs.com or to the issue tracker.

## Change

`package.json` only, metadata only — no runtime code, no build output, no
dependency changes.

```json
"description": "Free, open-source browser fingerprinting library. Identify returning visitors, detect fraud and bots — client-side, cookieless, no backend required.",
"repository": { "type": "git", "url": "git+https://github.com/thumbmarkjs/thumbmarkjs.git" },
"homepage": "https://www.thumbmarkjs.com",
"bugs": { "url": "https://github.com/thumbmarkjs/thumbmarkjs/issues" }
```

`license: MIT` and the 12 existing keywords were already correct and are
untouched. `funding` is deliberately left out of scope here; `.github/FUNDING.yml`
already covers the GitHub side.

The description is 148 characters, so it survives npm's search-result rendering
intact, and it matches the README's opening pitch line so npm and GitHub tell
the same story.

## Verification

- `package.json` parses; a duplicate-key check across every object reports none.
- Nothing rewrites `package.json` at publish time, so this reaches the registry:
  `rollup.config.mjs` emits only the bundles and the `.d.ts` rollup (no
  `generatePackageJson`, no copy step), the `Makefile` only copies UMD output,
  `prepublishOnly` is `npm run build && npm test`, and there is no publish
  workflow under `.github/`.
- Branched from `main` at v1.11.0.

## Note on rollout

Registry metadata is per-version, so 1.11.0 stays broken permanently — the fix
only reaches users on the next publish. Worth a patch release on its own.